### PR TITLE
Update apache logo

### DIFF
--- a/logos/apache.svg
+++ b/logos/apache.svg
@@ -1,857 +1,138 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<svg width="256px" height="76px" viewBox="0 0 256 76" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid">
-    <defs>
-        <linearGradient x1="48.3766971%" y1="-14.4748042%" x2="51.4390397%" y2="108.20454%" id="linearGradient-1">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="49.460987%" y1="25.1370861%" x2="52.0418201%" y2="134.884739%" id="linearGradient-2">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.221143%" y1="-15.7682157%" x2="51.6622108%" y2="108.575315%" id="linearGradient-3">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.8455932%" y1="14.3707876%" x2="52.5519507%" y2="133.905532%" id="linearGradient-4">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.4773512%" y1="-17.0181125%" x2="51.6532459%" y2="108.531087%" id="linearGradient-5">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.9573055%" y1="4.90840544%" x2="52.1411808%" y2="155.044045%" id="linearGradient-6">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.7470325%" y1="-20.5688086%" x2="51.5706737%" y2="111.805424%" id="linearGradient-7">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.9014553%" y1="-8.2638852%" x2="51.9641366%" y2="139.506575%" id="linearGradient-8">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.8783436%" y1="-40.5677323%" x2="49.7517809%" y2="35.508044%" id="linearGradient-9">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="61.2950036%" y1="-95.7542166%" x2="47.1669901%" y2="83.3767768%" id="linearGradient-10">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.7627526%" y1="-62.5549028%" x2="49.8289209%" y2="31.5172942%" id="linearGradient-11">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="61.8915616%" y1="-134.185589%" x2="44.0316209%" y2="133.251663%" id="linearGradient-12">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="47.9621439%" y1="-127.500646%" x2="49.5842417%" y2="28.726395%" id="linearGradient-13">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.0082885%" y1="-165.229325%" x2="49.9982847%" y2="24.9601161%" id="linearGradient-14">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="49.4204991%" y1="-96.0901922%" x2="51.3313938%" y2="148.654117%" id="linearGradient-15">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="47.2850385%" y1="-269.552579%" x2="50.254724%" y2="94.9727508%" id="linearGradient-16">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="36.8117643%" y1="136.870384%" x2="63.3196808%" y2="-33.2912657%" id="linearGradient-17">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="51.2678729%" y1="47.7972879%" x2="111.195249%" y2="-92.9815632%" id="linearGradient-18">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="28.8608793%" y1="154.569829%" x2="66.465133%" y2="-25.9394885%" id="linearGradient-19">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="39.4057397%" y1="88.5229443%" x2="98.5995279%" y2="-60.131647%" id="linearGradient-20">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="30.2073245%" y1="198.315613%" x2="63.3422197%" y2="-44.5529191%" id="linearGradient-21">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="23.3525723%" y1="145.50073%" x2="83.0328956%" y2="-60.8837983%" id="linearGradient-22">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="27.9563567%" y1="228.377354%" x2="59.9125405%" y2="-21.2995824%" id="linearGradient-23">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="50.0468279%" y1="55.2451317%" x2="50.9488352%" y2="155.803843%" id="linearGradient-24">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="52.9348299%" y1="4.41588253%" x2="41.0031888%" y2="204.290039%" id="linearGradient-25">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="54.5577779%" y1="-13.0721165%" x2="39.844148%" y2="224.278444%" id="linearGradient-26">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="58.2441761%" y1="-110.719102%" x2="35.8840924%" y2="341.375938%" id="linearGradient-27">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="48.7387763%" y1="-111.609454%" x2="50.6128505%" y2="138.353811%" id="linearGradient-28">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="49.4502913%" y1="4.04335935%" x2="50.5976945%" y2="145.151657%" id="linearGradient-29">
-            <stop stop-color="#F8E47F" offset="0%"></stop>
-            <stop stop-color="#F7DB7C" offset="10.57%"></stop>
-            <stop stop-color="#F3C87B" offset="34.93%"></stop>
-            <stop stop-color="#F2C179" offset="51.98%"></stop>
-            <stop stop-color="#F6D17B" offset="70.96%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="106.724158%" y1="8.25249108%" x2="0.727065%" y2="121.341091%" id="linearGradient-30">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="99.5418431%" y1="11.0888041%" x2="9.96758254%" y2="104.951544%" id="linearGradient-31">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="87.195506%" y1="12.4264207%" x2="13.244046%" y2="100.149353%" id="linearGradient-32">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="80.2907526%" y1="14.0911901%" x2="21.4044626%" y2="97.1555616%" id="linearGradient-33">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="76.025046%" y1="-4.77798478%" x2="25.9173294%" y2="100.047107%" id="linearGradient-34">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#873A93" offset="9.59%"></stop>
-            <stop stop-color="#9E3B90" offset="24.69%"></stop>
-            <stop stop-color="#C23B89" offset="43.29%"></stop>
-            <stop stop-color="#EC3E81" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="54.8049385%" y1="35.2297898%" x2="35.2348683%" y2="97.2813156%" id="linearGradient-35">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="56.0746536%" y1="31.5894512%" x2="41.8889221%" y2="89.9027201%" id="linearGradient-36">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="54.6886854%" y1="22.487617%" x2="32.0786365%" y2="154.954459%" id="linearGradient-37">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="56.2494693%" y1="25.1048036%" x2="40.5926253%" y2="88.7892646%" id="linearGradient-38">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="55.8044702%" y1="12.8139922%" x2="33.1944212%" y2="155.28944%" id="linearGradient-39">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="54.1028045%" y1="7.85611091%" x2="46.7810145%" y2="83.4914712%" id="linearGradient-40">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="52.8144903%" y1="16.0187785%" x2="44.7704108%" y2="115.366485%" id="linearGradient-41">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="53.102613%" y1="11.8046156%" x2="44.4090118%" y2="118.906549%" id="linearGradient-42">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="55.4634826%" y1="0.975370495%" x2="37.3021839%" y2="159.67327%" id="linearGradient-43">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="54.8407468%" y1="-0.941153861%" x2="39.3817825%" y2="157.755956%" id="linearGradient-44">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="54.5715711%" y1="15.506944%" x2="44.5069636%" y2="89.968775%" id="linearGradient-45">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="54.2415283%" y1="-3.00905541%" x2="41.2077086%" y2="160.546943%" id="linearGradient-46">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="53.7753398%" y1="17.4479346%" x2="45.3212821%" y2="92.2933152%" id="linearGradient-47">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="53.9905502%" y1="-4.15846159%" x2="41.8603415%" y2="155.32898%" id="linearGradient-48">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="52.8936968%" y1="20.8177393%" x2="45.1513012%" y2="98.4648191%" id="linearGradient-49">
-            <stop stop-color="#7F3996" offset="0%"></stop>
-            <stop stop-color="#9C2F82" offset="7.1%"></stop>
-            <stop stop-color="#B92770" offset="15.99%"></stop>
-            <stop stop-color="#D02162" offset="25.42%"></stop>
-            <stop stop-color="#DF1E57" offset="35.54%"></stop>
-            <stop stop-color="#E91F52" offset="46.82%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="18.8003134%" y1="73.6468076%" x2="117.39748%" y2="-83.5027938%" id="linearGradient-50">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="27.7448264%" y1="80.1483356%" x2="109.998418%" y2="-58.8685377%" id="linearGradient-51">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="38.2099522%" y1="76.9222738%" x2="91.4001792%" y2="-54.6808405%" id="linearGradient-52">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="32.7425749%" y1="82.6860743%" x2="87.5792193%" y2="-44.6889925%" id="linearGradient-53">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="40.239698%" y1="78.5345965%" x2="84.9077339%" y2="-52.4234045%" id="linearGradient-54">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="33.9221333%" y1="87.7230288%" x2="78.7175163%" y2="-34.2446054%" id="linearGradient-55">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="41.1273531%" y1="77.8140157%" x2="78.0450137%" y2="-44.1742594%" id="linearGradient-56">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="40.8663957%" y1="81.9999823%" x2="80.1135535%" y2="-43.424582%" id="linearGradient-57">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="33.9089602%" y1="98.2067328%" x2="77.4770724%" y2="-29.1683334%" id="linearGradient-58">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="40.3096598%" y1="85.9808516%" x2="78.4460492%" y2="-51.0210921%" id="linearGradient-59">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="32.3761522%" y1="106.137066%" x2="74.7829208%" y2="-27.1471533%" id="linearGradient-60">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="39.5067174%" y1="90.205678%" x2="78.1905189%" y2="-48.937198%" id="linearGradient-61">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="31.2445969%" y1="113.210071%" x2="72.9101715%" y2="-28.0857674%" id="linearGradient-62">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="40.418512%" y1="97.3747443%" x2="72.374696%" y2="-52.7116547%" id="linearGradient-63">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="28.3892543%" y1="127.878742%" x2="69.1643119%" y2="-23.3319716%" id="linearGradient-64">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="39.3443593%" y1="105.26627%" x2="68.7440484%" y2="-45.6683751%" id="linearGradient-65">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="38.5670026%" y1="109.272229%" x2="67.7549955%" y2="-46.0500516%" id="linearGradient-66">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="39.2024762%" y1="117.022289%" x2="65.8853624%" y2="-33.0641099%" id="linearGradient-67">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="31.8553225%" y1="87.3329057%" x2="99.2086034%" y2="-50.6906205%" id="linearGradient-68">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="24.9913093%" y1="105.66897%" x2="90.1653887%" y2="-33.2013267%" id="linearGradient-69">
-            <stop stop-color="#6A3894" offset="0%"></stop>
-            <stop stop-color="#8A2F83" offset="10.58%"></stop>
-            <stop stop-color="#B4256C" offset="26.53%"></stop>
-            <stop stop-color="#D31C5D" offset="40.92%"></stop>
-            <stop stop-color="#E51E54" offset="53.09%"></stop>
-            <stop stop-color="#EC1E4F" offset="61.58%"></stop>
-            <stop stop-color="#F8E47F" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="139.779127%" y1="0.614642654%" x2="-149.958651%" y2="198.321967%" id="linearGradient-70">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="110.786277%" y1="-267.694984%" x2="29.2961981%" y2="157.981534%" id="linearGradient-71">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="103.51575%" y1="-125.978103%" x2="-26.867844%" y2="304.087929%" id="linearGradient-72">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="154.582009%" y1="-23.6996073%" x2="-217.942547%" y2="218.837013%" id="linearGradient-73">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="99.2112083%" y1="-20.8557126%" x2="-47.2872124%" y2="216.169014%" id="linearGradient-74">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="116.137181%" y1="-19.2975915%" x2="-120.923901%" y2="219.080955%" id="linearGradient-75">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="107.111596%" y1="-1209.88682%" x2="17.8073995%" y2="686.308584%" id="linearGradient-76">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="103.166067%" y1="-263.872807%" x2="33.4422203%" y2="149.160907%" id="linearGradient-77">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="120.64823%" y1="-176.666973%" x2="27.5178514%" y2="107.118095%" id="linearGradient-78">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-        <linearGradient x1="164.291094%" y1="-159.745011%" x2="3.32369259%" y2="104.282196%" id="linearGradient-79">
-            <stop stop-color="#D4E5EE" offset="0%"></stop>
-            <stop stop-color="#CDDFE8" offset="7.22%"></stop>
-            <stop stop-color="#B4CBD7" offset="18.58%"></stop>
-            <stop stop-color="#90ABBB" offset="32.67%"></stop>
-            <stop stop-color="#5F8096" offset="48.78%"></stop>
-            <stop stop-color="#486D86" offset="55.37%"></stop>
-            <stop stop-color="#5D7E95" offset="59.41%"></stop>
-            <stop stop-color="#88A3B5" offset="68.5%"></stop>
-            <stop stop-color="#AAC1CE" offset="77.34%"></stop>
-            <stop stop-color="#C1D5E0" offset="85.72%"></stop>
-            <stop stop-color="#D0E1EA" offset="93.48%"></stop>
-            <stop stop-color="#D4E5EE" offset="100%"></stop>
-        </linearGradient>
-    </defs>
-    <g>
-        <path d="M254.801872,62.0494505 L254.602184,61.9505495 L254.602184,61.3571429 L254.302652,60.5659341 L253.703588,59.8736264 L252.904836,59.3791209 L252.804992,59.1813187 L252.205928,58.5879121 L251.307332,58.0934066 L250.50858,57.7967033 L250.308892,57.7967033 L249.51014,57.1043956 L248.411856,56.510989 L247.213729,55.9175824 L245.915757,55.521978 L245.716069,55.521978 L244.717629,54.4340659 L243.519501,53.4450549 L242.321373,52.8516484 L241.123245,52.5549451 L240.923557,52.5549451 L239.825273,51.7637363 L238.028081,51.0714286 L237.229329,50.9725275 L236.131045,50.2802198 L234.932917,49.7857143 L233.834633,49.5879121 L232.636505,49.489011 L231.438378,49.5879121 L230.539782,49.7857143 L230.040562,48.8956044 L228.542902,47.9065934 L226.645866,47.510989 L224.948518,47.510989 L222.851794,47.9065934 L222.25273,48.1043956 L220.75507,47.510989 L219.057722,47.0164835 L217.26053,46.8186813 L215.563183,46.8186813 L213.765991,47.0164835 L213.566303,47.0164835 L211.769111,46.3241758 L209.872075,45.8296703 L207.975039,45.532967 L206.976599,45.4340659 L205.379095,43.9505495 L203.581903,42.6648352 L201.784711,41.7747253 L200.187207,41.2802198 L198.190328,41.1813187 L197.291732,41.2802198 L196.49298,40.5879121 L195.095164,39.9945055 L193.397816,39.7967033 L192.399376,39.9945055 L191.00156,39.5 L189.5039,39.1043956 L188.106084,38.9065934 L187.606864,38.9065934 L185.51014,38.1153846 L182.914197,37.4230769 L180.517941,37.2252747 L180.218409,37.2252747 L178.021841,35.9395604 L175.525741,35.3461538 L173.828393,35.3461538 L170.134165,34.456044 L167.73791,34.2582418 L166.939158,34.2582418 L165.74103,33.0714286 L164.043682,32.0824176 L162.146646,31.5879121 L160.24961,31.7857143 L159.051482,32.0824176 L157.453978,31.7857143 L155.75663,31.6868132 L153.75975,31.7857143 L153.659906,31.7857143 L153.659906,31.489011 L150.664587,30.7967033 L147.868955,30.4010989 L145.273011,30.3021978 L144.374415,30.4010989 L144.374415,30.3021978 L142.377535,30.0054945 L140.380655,29.8076923 L140.180967,29.8076923 L137.984399,28.9175824 L135.687988,28.3241758 L133.591264,28.0274725 L132.093604,28.0274725 L129.897036,27.2362637 L128.099844,26.8406593 L126.202808,26.7417582 L125.903276,26.7417582 L123.806552,25.3571429 L121.809672,24.5659341 L120.312012,24.3681319 L118.714509,23.5769231 L116.318253,22.9835165 L114.221529,23.0824176 L112.124805,22.0934066 L109.928237,21.5989011 L108.829953,21.5989011 L106.633385,20.4120879 L104.436817,19.8186813 L102.24025,19.7197802 L101.840874,19.8186813 L98.9453978,18.3351648 L96.74883,17.543956 L94.4524181,17.3461538 L94.3525741,17.3461538 L93.1544462,16.6538462 L91.8564743,16.0604396 L90.4586583,15.6648352 L88.9609984,15.5659341 L87.7628705,15.6648352 L86.3650546,14.6758242 L84.6677067,13.9835165 L82.7706708,13.6868132 L81.1731669,13.7857143 L79.276131,14.1813187 L79.0764431,14.2802198 L77.1794072,13.3901099 L75.1825273,12.8956044 L73.2854914,12.7967033 L71.7878315,11.8076923 L70.1903276,11.2142857 L68.4929797,11.0164835 L66.8954758,11.2142857 L65.4976599,11.6098901 L64.399376,10.521978 L63.0015601,9.63186813 L61.3042122,9.33516484 L59.8065523,9.63186813 L58.7082683,10.1263736 L58.0093604,9.63186813 L57.3104524,9.33516484 L56.5117005,9.03846154 L55.9126365,8.93956044 L55.0140406,9.03846154 L54.1154446,9.33516484 L53.2168487,9.92857143 L53.0171607,10.1263736 L51.3198128,9.73076923 L49.6224649,9.82967033 L48.124805,10.3241758 L46.9266771,11.2142857 L45.9282371,12.4010989 L45.2293292,13.8846154 L44.7301092,15.467033 L44.3307332,17.1483516 L44.1310452,18.8296703 L44.2308892,26.3461538 C43.2324493,25.9505495 42.2340094,25.5549451 41.3354134,25.2582418 L41.4352574,24.1703297 L41.6349454,22.9835165 L41.7347894,21.6978022 L41.8346334,20.4120879 L41.9344774,19.2252747 L42.0343214,18.0384615 L41.9344774,16.8516484 L41.8346334,15.6648352 L41.7347894,14.478022 L41.5351014,13.489011 L41.2355694,12.5 L41.1357254,12.1043956 L41.2355694,11.8076923 L41.5351014,10.8186813 L41.9344774,9.82967033 L42.2340094,8.84065934 L42.7332293,7.85164835 L41.0358814,9.43406593 L40.2371295,10.1263736 L39.9375975,9.73076923 L39.2386895,9.03846154 L38.4399376,8.44505495 L38.6396256,9.63186813 L38.8393136,10.8186813 L39.0390016,11.6098901 L38.5397816,12.3021978 L38.2402496,12.9945055 L38.1404056,12.6978022 L37.9407176,12.1043956 L37.7410296,11.4120879 L37.5413417,10.6208791 L37.5413417,9.92857143 L37.4414977,9.13736264 L37.3416537,8.44505495 L37.2418097,7.65384615 L37.2418097,6.86263736 L37.3416537,6.17032967 L37.4414977,5.47802198 L37.5413417,4.78571429 L37.7410296,4.09340659 L37.9407176,3.5 L37.0421217,4.68681319 L36.3432137,5.97252747 L35.8439938,7.25824176 L35.5444618,8.54395604 L35.4446178,9.92857143 L35.4446178,11.3131868 L35.6443058,12.6978022 L35.9438378,14.0824176 L36.2433697,15.1703297 L35.7441498,14.8736264 L35.2449298,14.1813187 L34.6458658,13.3901099 L34.0468019,12.5989011 L33.5475819,11.7087912 L33.0483619,10.7197802 L32.648986,9.53296703 L32.349454,8.14835165 L32.24961,6.56593407 L31.1513261,7.55494505 L30.5522621,8.64285714 L30.2527301,9.82967033 L30.2527301,11.0164835 L30.4524181,12.2032967 L30.9516381,13.489011 L31.550702,14.7747253 L32.149766,15.7637363 L31.0514821,15.5659341 L29.8533541,15.467033 L30.6521061,15.9615385 L31.450858,16.456044 L32.24961,16.9505495 L32.9485179,17.4450549 L33.6474259,17.9395604 L34.2464899,18.532967 L35.2449298,19.6208791 L36.2433697,20.6098901 L37.1419657,21.5989011 L37.9407176,22.489011 L38.6396256,23.2802198 L39.0390016,23.7747253 L39.4383775,24.2692308 L39.6380655,24.5659341 C27.9563183,19.9175824 15.375975,14.3791209 -1.42108547e-14,7.06043956 C3.09516381,12.1043956 14.4773791,17.3461538 19.1700468,20.9065934 C24.1622465,23.5769231 31.0514821,26.4450549 37.0421217,28.7197802 L35.7441498,29.0164835 L34.4461778,29.2142857 L33.9469579,29.3131868 L33.6474259,29.3131868 L32.74883,29.4120879 L31.850234,29.510989 L30.9516381,29.510989 L30.0530421,29.6098901 L29.2542902,29.6098901 L28.2558502,29.6098901 L27.3572543,29.510989 L26.4586583,29.4120879 L25.5600624,29.3131868 L24.6614665,29.2142857 L23.7628705,29.0164835 L22.8642746,28.8186813 L23.8627145,29.510989 L24.8611544,30.1043956 L25.8595944,30.5 L26.8580343,30.7967033 L27.4570983,30.8956044 L26.1591264,31.2912088 L24.8611544,31.7857143 L23.2636505,32.6758242 L22.0655226,33.467033 L21.0670827,34.2582418 L20.1684867,35.2472527 L19.3697348,36.2362637 L18.7706708,37.4230769 L18.3712949,38.8076923 L18.7706708,38.3131868 L19.2698908,37.8186813 L19.7691108,37.3241758 L20.2683307,36.8296703 L20.8673947,36.4340659 L21.4664587,36.0384615 L22.0655226,35.6428571 L22.6645866,35.2472527 L23.3634945,34.9505495 L23.9625585,34.6538462 L24.6614665,34.456044 L25.3603744,34.1593407 L26.0592824,33.9615385 L26.7581903,33.7637363 L27.3572543,33.6648352 L28.0561622,33.5659341 L29.2542902,33.0714286 L30.5522621,32.3791209 L31.850234,31.5879121 L33.1482059,30.7967033 L34.3463339,30.1043956 L34.9453978,29.9065934 L35.0452418,29.9065934 L34.1466459,30.4010989 L33.2480499,30.9945055 L32.24961,31.5879121 L31.25117,32.2802198 L30.3525741,32.8736264 L29.3541342,33.467033 L28.4555382,34.0604396 L27.4570983,34.6538462 L26.4586583,35.2472527 L25.4602184,35.8406593 L24.4617785,36.4340659 L23.4633385,37.0274725 L22.2652106,37.8186813 L21.1669267,38.4120879 L22.2652106,38.510989 L23.3634945,38.4120879 L24.3619345,38.2142857 L25.3603744,37.9175824 L26.3588144,37.521978 L26.0592824,37.8186813 L25.3603744,38.9065934 L24.8611544,40.0934066 L24.6614665,41.3791209 L24.8611544,42.6648352 L25.3603744,43.9505495 L26.1591264,42.467033 L26.9578783,41.2802198 L27.7566303,40.1923077 L28.5553822,39.3021978 L29.3541342,38.6098901 L30.2527301,38.0164835 L31.1513261,37.4230769 L32.049922,36.9285714 L32.549142,36.6318681 L32.449298,36.7307692 L32.149766,38.0164835 L31.950078,39.5989011 L32.049922,41.2802198 L32.349454,43.1593407 L32.9485179,45.3351648 L33.1482059,44.2472527 L33.3478939,43.2582418 L33.6474259,42.2692308 L33.9469579,41.2802198 L34.2464899,40.2912088 L34.6458658,39.4010989 L35.0452418,38.4120879 L35.5444618,37.4230769 L36.0436817,36.532967 L36.5429017,35.6428571 L37.0421217,34.6538462 L37.5413417,33.7637363 L38.1404056,32.8736264 L38.7394696,31.8846154 L39.3385335,30.8956044 L39.8377535,30.1043956 C40.6365055,30.4010989 41.3354134,30.6978022 42.0343214,30.8956044 L40.7363495,33.0714286 L39.5382215,35.4450549 L38.5397816,38.3131868 L38.1404056,39.8956044 L38.0405616,41.3791209 L38.1404056,42.8626374 L38.4399376,44.1483516 L39.1388456,45.532967 L40.2371295,46.7197802 L41.8346334,47.6098901 L43.4321373,48.1043956 L43.8315133,48.9945055 L44.7301092,50.1813187 L45.6287051,50.9725275 L46.4274571,51.5659341 L47.326053,52.0604396 L48.224649,52.3571429 L49.0234009,52.456044 L50.0218409,52.456044 L50.9204368,53.6428571 L52.2184087,54.6318681 L53.7160686,55.2252747 L55.5132605,55.3241758 L56.9110764,54.9285714 L57.1107644,55.2252747 L58.4087363,56.4120879 L59.7067083,57.3021978 L61.0046802,57.8956044 L62.8018721,58.1923077 L63.900156,58.0934066 L64.9984399,58.8846154 L66.6957878,59.5769231 L68.1934477,59.9725275 L69.2917317,60.7637363 L71.0889236,61.5549451 L73.3853354,62.0494505 L75.4820593,62.1483516 L75.5819033,62.2472527 L77.1794072,63.4340659 L78.7769111,64.3241758 L80.274571,64.8186813 L82.1716069,65.0164835 L83.8689548,64.7197802 L84.5678627,65.1153846 L85.8658346,65.7087912 L87.2636505,66.0054945 L88.5616225,66.1043956 L89.7597504,65.9065934 L90.1591264,66.2032967 L92.2558502,66.8956044 L94.6521061,67.1923077 L97.2480499,67.0934066 L97.7472699,67.3901099 L99.8439938,68.0824176 L101.940718,68.3791209 L104.736349,68.2802198 L106.533541,68.8736264 L108.730109,69.1703297 L110.826833,69.0714286 L111.525741,69.467033 L113.622465,70.2582418 L116.018721,70.5549451 L118.414977,70.2582418 L118.414977,70.1593407 L119.613105,70.456044 L121.609984,70.456044 L123.806552,69.9615385 L125.104524,70.456044 L126.801872,70.8516484 L128.49922,71.0494505 L130.595944,71.0494505 L131.095164,71.2472527 L133.092044,71.8406593 L135.188768,72.2362637 L137.485179,72.3351648 L139.781591,72.1373626 L139.781591,72.0384615 L140.979719,72.3351648 L142.876755,72.6318681 L144.773791,72.7307692 L144.873635,72.532967 L146.171607,72.9285714 L148.667707,73.3241758 L151.363495,73.4230769 L154.25897,73.3241758 L154.658346,73.4230769 L156.455538,73.8186813 L158.152886,74.0164835 L159.850234,74.1153846 L159.950078,74.2142857 L161.547582,75.0054945 L163.444618,75.5 L165.141966,75.5 L166.939158,75.1043956 L168.436817,74.2142857 L170.134165,74.7087912 L172.430577,74.9065934 L174.826833,74.9065934 L175.326053,75.1043956 L177.722309,75.5 L180.018721,75.3021978 L182.414977,74.510989 L184.411856,74.7087912 L186.907956,74.6098901 L188.804992,74.3131868 L189.903276,74.510989 L191.301092,74.6098901 L194.396256,74.3131868 L195.394696,74.7087912 L196.892356,74.9065934 L198.190328,74.6098901 L199.188768,74.1153846 L199.288612,74.1153846 L200.886115,74.6098901 L202.583463,74.9065934 L204.280811,74.9065934 L206.078003,74.510989 L207.975039,73.6208791 L209.772231,72.532967 L211.170047,72.6318681 L213.067083,72.532967 L214.664587,72.3351648 L215.563183,72.6318681 L217.160686,72.9285714 L218.75819,73.1263736 L220.455538,73.0274725 L222.053042,72.7307692 L222.352574,72.8296703 L224.349454,73.521978 L226.146646,73.9175824 L227.74415,73.9175824 L229.341654,73.4230769 L230.140406,72.6318681 L230.539782,72.7307692 L231.638066,73.0274725 L232.736349,73.2252747 L233.934477,73.1263736 L235.032761,72.9285714 L235.831513,72.6318681 L237.229329,72.7307692 L238.726989,72.532967 L240.124805,71.9395604 L240.324493,71.9395604 L241.722309,71.8406593 L242.920437,71.6428571 L244.318253,71.0494505 L245.316693,70.3571429 L246.614665,70.3571429 L247.812793,70.1593407 L248.911076,69.8626374 L250.109204,69.3681319 L250.608424,69.3681319 L251.307332,69.2692308 L252.00624,68.9725275 L252.205928,68.7747253 L253.00468,68.6758242 L253.903276,68.2802198 L254.302652,67.5879121 L254.402496,67.0934066 L254.702028,67.0934066 L255.600624,66.2032967 L255.700468,65.8076923 L255.900156,65.9065934 L256,63.4340659 L254.801872,62.0494505 L254.801872,62.0494505 Z M41.2355694,25.2582418 C40.7363495,25.0604396 40.2371295,24.8626374 39.7379095,24.6648352 L39.6380655,24.467033 L39.6380655,24.2692308 L39.7379095,24.467033 L39.6380655,24.1703297 L39.6380655,23.7747253 L39.7379095,22.5879121 L39.8377535,21.4010989 L39.9375975,20.2142857 L40.0374415,19.1263736 L40.1372855,18.3351648 L40.2371295,19.2252747 L40.3369735,20.2142857 L40.5366615,21.2032967 L40.7363495,22.1923077 L40.9360374,23.1813187 L41.1357254,24.1703297 L41.2355694,25.2582418 L41.2355694,25.2582418 Z M37.0421217,28.8186813 L37.1419657,28.8186813 L36.6427457,29.1153846 L36.4430577,29.1153846 L36.0436817,29.1153846 L36.3432137,28.9175824 L37.0421217,28.8186813 L37.0421217,28.8186813 Z M34.4461778,31.5879121 L35.3447738,30.6978022 L36.2433697,29.7087912 L36.6427457,29.3131868 L37.2418097,29.0164835 L36.8424337,29.1153846 L37.0421217,28.9175824 C37.5413417,29.1153846 38.1404056,29.3131868 38.6396256,29.510989 L38.0405616,29.9065934 L37.0421217,30.4010989 L35.8439938,30.9945055 L34.6458658,31.5879121 L33.9469579,31.8846154 L34.4461778,31.5879121 L34.4461778,31.5879121 Z M39.6380655,30.2032967 L39.1388456,30.6978022 L38.4399376,31.0934066 L37.8408736,31.489011 L38.0405616,31.0934066 L38.8393136,29.510989 C39.2386895,29.7087912 39.6380655,29.8076923 40.0374415,29.9065934 L39.6380655,30.2032967 L39.6380655,30.2032967 Z" fill="#DCDDDE"></path>
-        <g stroke="#231F20">
-            <path d="M255.8,61.8 C235.2,59 159,55.1 125.1,49.6 C97.8,45.1 71.1,37 45.6,28.5 C39,26.3 27.4,21.8 19.9,17.7 C15.2,14.1 3.8,8.7 0.7,3.7 C50.1,27.1 70,33.5 127.9,45.3 C151.4,50.1 236.8,57 255.8,61.8 L255.8,61.8 Z" stroke-width="0.5956" fill="#231F20"></path>
-            <path d="M182.8,70.9 L182.8,70.9 L180.6,71.7 L178.4,71.8 L176.3,71.5 L174.1,70.6 L172,69.5 L169.9,67.9 L167.9,66.2 L166,64.3 L164.1,62.4 L162.3,60.5 L160.6,58.6 L159.1,56.9 L157.6,55.4 L156.3,54.3 L155.1,53.5 L154.1,53.2 L154.9,53.2 L155.9,53.3 L156.9,53.4 L158,53.5 L159,53.6 L160.1,53.7 L161.1,53.8 L162,53.9 L163.5,55.3 L164.9,56.5 L166.1,57.8 L167.2,59.1 L168.3,60.3 L169.4,61.5 L170.4,62.7 L171.4,63.8 L172.5,64.9 L173.6,65.9 L174.8,66.9 L176.1,67.8 L177.5,68.7 L179.1,69.5 L180.8,70.3 L182.8,70.9 Z" stroke-width="0.254" fill="url(#linearGradient-1)"></path>
-            <path d="M190,70.6 L190,70.6 L187.5,71 L185.1,71.1 L182.9,70.9 L180.8,70.3 L178.8,69.5 L177.1,68.5 L175.3,67.4 L173.8,66 L172.2,64.6 L170.7,63.1 L169.3,61.5 L167.9,59.9 L166.4,58.3 L165,56.8 L163.5,55.3 L162,54 L162.6,54 L163.2,54 L163.8,54.1 L164.4,54.1 L165.1,54.2 L165.7,54.3 L166.4,54.4 L167,54.4 L167.6,54.5 L168.3,54.6 L169,54.7 L169.7,54.7 L170.4,54.8 L171.1,54.8 L171.8,54.8 L172.5,54.9 L173,55.7 L173.6,56.7 L174.5,57.9 L175.3,59.1 L176.4,60.4 L177.5,61.8 L178.7,63.2 L179.9,64.5 L181.2,65.8 L182.4,67 L183.8,68.1 L185.1,69 L186.3,69.8 L187.6,70.3 L188.9,70.6 L190,70.6 Z" stroke-width="0.254" fill="url(#linearGradient-2)"></path>
-            <path d="M194.8,70.7 L194.8,70.7 L193.3,70.8 L191.9,71 L190.6,70.9 L189.3,70.7 L187.9,70.4 L186.6,69.9 L185.4,69.2 L184,68.3 L182.7,67.4 L181.3,66.2 L180,64.8 L178.6,63.3 L177.1,61.5 L175.6,59.5 L174,57.3 L172.4,54.9 L173.4,54.9 L174.3,55 L175.3,55.1 L176.2,55.2 L177.1,55.3 L178.1,55.4 L179.1,55.4 L180.2,55.4 L181.2,56.3 L182,57.3 L182.9,58.3 L183.8,59.3 L184.6,60.3 L185.5,61.4 L186.3,62.3 L187.2,63.4 L188,64.4 L188.9,65.4 L189.8,66.4 L190.7,67.3 L191.7,68.2 L192.7,69 L193.7,69.9 L194.8,70.7 Z" stroke-width="0.254" fill="url(#linearGradient-3)"></path>
-            <path d="M199.9,70.4 L199.9,70.4 L198.8,71 L197.5,71.2 L196.3,71.1 L195,70.6 L193.7,69.8 L192.4,68.7 L191.1,67.6 L189.7,66.2 L188.4,64.7 L187.1,63.2 L185.9,61.7 L184.6,60.2 L183.5,58.8 L182.4,57.5 L181.3,56.4 L180.4,55.5 L186.6,56.1 L187.3,57 L188.1,57.9 L188.8,58.9 L189.5,59.8 L190.2,60.7 L190.9,61.6 L191.6,62.6 L192.4,63.5 L193.2,64.4 L194,65.3 L194.8,66.2 L195.8,67.1 L196.7,67.9 L197.7,68.8 L198.8,69.6 L199.9,70.4 Z" stroke-width="0.254" fill="url(#linearGradient-4)"></path>
-            <path d="M210.2,69.1 L210.2,69.1 L208.4,70.2 L206.7,71 L205,71.4 L203.4,71.4 L201.8,71.1 L200.3,70.5 L198.8,69.7 L197.4,68.7 L196,67.4 L194.6,66.1 L193.3,64.5 L191.9,62.9 L190.6,61.2 L189.4,59.5 L188.1,57.7 L186.9,56.1 L188,56.2 L188.8,56.3 L189.4,56.3 L189.9,56.4 L190.4,56.5 L190.9,56.5 L191.7,56.5 L192.7,56.6 L193.8,58.1 L194.9,59.6 L196,61 L197.2,62.2 L198.4,63.3 L199.6,64.4 L200.8,65.3 L202,66.1 L203.1,66.8 L204.3,67.5 L205.4,67.9 L206.4,68.3 L207.5,68.7 L208.4,68.9 L209.4,69 L210.2,69.1 Z" stroke-width="0.254" fill="url(#linearGradient-5)"></path>
-            <path d="M215.6,68.7 L215.6,68.7 L213.7,69 L211.9,69.1 L210.2,69 L208.5,68.7 L206.9,68.4 L205.3,67.9 L203.9,67.2 L202.5,66.4 L201.1,65.5 L199.8,64.5 L198.5,63.4 L197.3,62.2 L196.1,60.9 L195,59.5 L193.9,58.1 L192.9,56.6 L194,56.6 L195.3,56.7 L196.5,56.9 L197.8,56.9 L198.8,57 L199.7,57.1 L200.3,57.1 L200.6,57.2 L200.7,57.3 L201,57.6 L201.5,58.1 L202.1,58.7 L202.7,59.4 L203.5,60.2 L204.4,61 L205.4,62 L206.5,62.9 L207.7,63.9 L208.8,64.8 L210.1,65.8 L211.4,66.6 L212.8,67.4 L214.2,68.1 L215.6,68.7 Z" stroke-width="0.254" fill="url(#linearGradient-6)"></path>
-            <path d="M222.7,69.1 L222.7,69.1 L221.2,69.4 L219.7,69.5 L218.1,69.4 L216.5,69.1 L214.9,68.6 L213.4,67.9 L211.9,67.2 L210.4,66.2 L209,65.2 L207.6,64.2 L206.3,63.1 L205,61.9 L203.8,60.7 L202.6,59.5 L201.5,58.4 L200.5,57.2 L201.2,57.2 L202.1,57.3 L203.1,57.3 L204,57.3 L205,57.4 L205.9,57.5 L206.7,57.6 L207.3,57.7 L207.3,57.8 L207.5,58.1 L208.1,58.6 L208.9,59.2 L209.9,60.1 L211.1,61 L212.4,62 L213.7,63 L215.1,64 L216.5,65.1 L217.9,66 L219.1,66.9 L220.3,67.7 L221.4,68.4 L222.2,68.8 L222.7,69.1 Z" stroke-width="0.254" fill="url(#linearGradient-7)"></path>
-            <path d="M230.7,69.1 L230.7,69.1 L229.7,70 L228.5,70.4 L227,70.4 L225.3,70 L223.4,69.3 L221.5,68.3 L219.5,67.2 L217.5,65.9 L215.5,64.5 L213.7,63.1 L211.9,61.7 L210.4,60.5 L209.1,59.4 L208.1,58.5 L207.4,58 L207.1,57.7 L207.9,57.8 L208.7,57.8 L209.6,57.9 L210.4,58 L211.4,58.1 L212.3,58.1 L213.2,58.2 L214.2,58.2 L215.3,58.9 L216.3,59.5 L217.4,60.2 L218.4,60.9 L219.4,61.6 L220.4,62.3 L221.5,63 L222.5,63.7 L223.5,64.5 L224.5,65.2 L225.5,65.9 L226.5,66.6 L227.6,67.2 L228.6,67.8 L229.6,68.5 L230.7,69.1 Z" stroke-width="0.254" fill="url(#linearGradient-8)"></path>
-            <path d="M236.5,69.2 L236.5,69.2 L235.5,69.5 L234.5,69.7 L233.5,69.8 L232.5,69.6 L231.5,69.3 L230.5,68.9 L229.4,68.3 L228.2,67.6 L226.9,66.8 L225.6,65.9 L224.1,64.8 L222.5,63.7 L220.7,62.5 L218.8,61.2 L216.7,59.8 L214.4,58.3 L215.3,58.4 L216.5,58.4 L217.4,58.4 L218.4,58.5 L219.3,58.5 L220,58.6 L220.5,58.7 L220.6,58.7 L220.8,58.9 L221.1,59.2 L221.6,59.7 L222.3,60.3 L223.2,61.1 L224.2,62 L225.2,62.8 L226.5,63.8 L227.7,64.7 L229,65.6 L230.3,66.4 L231.6,67.3 L232.9,68 L234.2,68.5 L235.4,68.9 L236.5,69.2 Z" stroke-width="0.254" fill="url(#linearGradient-9)"></path>
-            <path d="M240.7,68.5 L240.7,68.5 L239.4,69.1 L238,69.3 L236.4,69.2 L234.9,68.8 L233.2,68.2 L231.7,67.4 L230,66.5 L228.5,65.5 L227.1,64.4 L225.7,63.3 L224.4,62.3 L223.3,61.2 L222.3,60.3 L221.5,59.6 L220.9,59.1 L220.6,58.7 L221.5,58.8 L222.4,58.8 L223.3,58.9 L224.1,59 L225,59.1 L225.8,59.1 L226.8,59.2 L227.7,59.3 L228.4,59.9 L229.2,60.6 L229.8,61.2 L230.6,61.9 L231.4,62.7 L232.1,63.4 L232.9,64.1 L233.8,64.8 L234.6,65.4 L235.4,66 L236.3,66.6 L237.1,67.1 L238,67.6 L238.9,68 L239.8,68.3 L240.7,68.5 Z" stroke-width="0.254" fill="url(#linearGradient-10)"></path>
-            <path d="M245.9,66.9 L245.9,66.9 L244.7,67.7 L243.5,68.2 L242.4,68.5 L241.2,68.5 L240,68.3 L238.9,67.9 L237.7,67.4 L236.6,66.7 L235.4,66 L234.3,65 L233.2,64.1 L232.1,63.1 L231,62.1 L229.9,61.1 L228.9,60.1 L227.8,59.2 L228.5,59.2 L229.1,59.3 L229.9,59.4 L230.7,59.5 L231.6,59.6 L232.5,59.6 L233.5,59.7 L234.5,59.8 L234.7,60.5 L235.1,61.2 L235.6,61.8 L236.1,62.5 L236.7,63.1 L237.3,63.6 L237.9,64.2 L238.7,64.7 L239.5,65.2 L240.3,65.6 L241.2,66 L242,66.3 L243,66.5 L243.9,66.7 L244.9,66.8 L245.9,66.9 Z" stroke-width="0.254" fill="url(#linearGradient-11)"></path>
-            <path d="M250.5,66 L250.5,66 L249.5,66.4 L248.4,66.7 L247.3,66.9 L246.1,66.9 L244.9,66.8 L243.7,66.7 L242.4,66.3 L241.2,66 L240,65.4 L238.9,64.9 L237.9,64.2 L237,63.5 L236.2,62.7 L235.5,61.8 L235,60.8 L234.6,59.8 L235.3,59.9 L236,59.9 L236.8,60 L237.5,60.1 L238.3,60.1 L239.1,60.2 L240,60.3 L241,60.3 L241.4,60.9 L241.9,61.5 L242.3,62 L242.8,62.5 L243.2,62.9 L243.8,63.3 L244.3,63.7 L244.8,64 L245.4,64.3 L246,64.6 L246.7,64.9 L247.4,65.2 L248.1,65.4 L248.8,65.6 L249.7,65.8 L250.5,66 Z" stroke-width="0.254" fill="url(#linearGradient-12)"></path>
-            <path d="M252.9,65.2 L252.9,65.2 L252.5,65.6 L252,65.8 L251.3,65.9 L250.6,65.9 L249.8,65.8 L249,65.7 L248,65.4 L247.1,65.1 L246.2,64.7 L245.2,64.2 L244.3,63.7 L243.5,63.1 L242.7,62.5 L242,61.8 L241.4,61.1 L241,60.3 L241.5,60.4 L242,60.4 L242.5,60.5 L243.1,60.6 L243.6,60.6 L244.1,60.7 L244.5,60.7 L244.9,60.7 L244.9,60.9 L245.4,61.4 L246.3,62 L247.4,62.8 L248.8,63.5 L250.2,64.3 L251.6,64.9 L252.9,65.2 Z" stroke-width="0.254" fill="url(#linearGradient-13)"></path>
-            <path d="M254.5,63.6 L254.5,63.6 L254.4,64.4 L254.1,64.9 L253.7,65.1 L253,65.3 L252.3,65.1 L251.4,64.9 L250.5,64.5 L249.6,64 L248.7,63.5 L247.8,62.9 L246.9,62.4 L246.2,61.8 L245.6,61.4 L245.1,61 L244.8,60.8 L244.8,60.7 L249.3,61.2 L249.7,61.4 L250.2,61.7 L250.9,62.1 L251.7,62.4 L252.5,62.8 L253.3,63.1 L254,63.4 L254.5,63.6 Z" stroke-width="0.254" fill="url(#linearGradient-14)"></path>
-            <path d="M249.3,61.2 L249.3,61.2 L250.3,61.2 L251.2,61.3 L252,61.4 L252.7,61.4 L253.4,61.5 L254.2,61.5 L255,61.7 L255.8,61.8 L255.7,62.9 L255.1,63.5 L254.3,63.5 L253.3,63.2 L252.2,62.6 L251.1,62.1 L250.1,61.5 L249.3,61.2 Z" stroke-width="0.254" fill="url(#linearGradient-15)"></path>
-            <path d="M249.5,60.6 L249.5,60.6 L250.5,60.8 L251.3,60.9 L252.1,61.1 L252.9,61.2 L253.6,61.4 L254.3,61.5 L255.1,61.7 L255.9,61.9 L256,60.7 L255.5,59.8 L254.7,59.6 L253.6,59.5 L252.4,59.7 L251.2,60 L250.2,60.4 L249.5,60.6 Z" stroke-width="0.254" fill="url(#linearGradient-16)"></path>
-            <path d="M188.9,36.9 L188.9,36.9 L186.3,36 L183.9,35.3 L181.6,35.1 L179.4,35.3 L177.3,35.7 L175.4,36.4 L173.6,37.4 L171.8,38.5 L170,39.8 L168.3,41.2 L166.6,42.7 L165,44.2 L163.4,45.6 L161.7,47 L160.1,48.4 L158.4,49.6 L159,49.7 L159.7,49.8 L160.3,49.8 L160.9,50 L161.5,50 L162.2,50.1 L162.9,50.1 L163.5,50.2 L164.1,50.2 L164.8,50.3 L165.5,50.4 L166.2,50.5 L166.9,50.5 L167.6,50.6 L168.3,50.7 L169,50.8 L169.6,50 L170.4,49 L171.2,47.9 L172.3,46.7 L173.4,45.4 L174.6,44.1 L176,42.8 L177.3,41.6 L178.8,40.4 L180.2,39.4 L181.7,38.5 L183.2,37.7 L184.6,37.1 L186.1,36.8 L187.5,36.7 L188.9,36.9 Z" stroke-width="0.254" fill="url(#linearGradient-17)"></path>
-            <path d="M193.3,37.9 L193.3,37.9 L191.8,37.4 L190.4,37.1 L189.1,36.8 L187.7,36.7 L186.3,36.8 L184.9,37.1 L183.6,37.5 L182.2,38.2 L180.7,39 L179.3,40 L177.8,41.3 L176.2,42.7 L174.5,44.4 L172.8,46.3 L171,48.5 L169.1,50.9 L170.1,50.9 L171.1,51.1 L171.9,51.1 L172.8,51.2 L173.6,51.3 L174.4,51.5 L175.4,51.6 L176.6,51.8 L177.7,50.9 L178.6,50 L179.7,49 L180.6,48 L181.6,47 L182.6,46 L183.5,45 L184.5,44.1 L185.5,43.1 L186.6,42.3 L187.5,41.4 L188.6,40.5 L189.7,39.7 L190.9,39.1 L192,38.5 L193.3,37.9 Z" stroke-width="0.254" fill="url(#linearGradient-18)"></path>
-            <path d="M198.1,39.2 L198.1,39.2 L197,38.3 L195.8,37.8 L194.5,37.7 L193.1,38 L191.7,38.6 L190.2,39.4 L188.7,40.4 L187.2,41.7 L185.7,43 L184.2,44.4 L182.7,45.8 L181.3,47.3 L180,48.6 L178.8,49.8 L177.7,50.9 L176.6,51.8 L183,52.5 L183.8,51.6 L184.6,50.6 L185.3,49.7 L186.2,48.8 L187,47.8 L187.8,46.9 L188.7,45.9 L189.5,45 L190.4,44.2 L191.3,43.3 L192.3,42.5 L193.4,41.7 L194.5,41 L195.6,40.3 L196.9,39.7 L198.1,39.2 Z" stroke-width="0.254" fill="url(#linearGradient-19)"></path>
-            <path d="M207.7,43.3 L207.7,43.3 L206,41.6 L204.3,40.4 L202.6,39.6 L201,39.1 L199.4,39 L197.8,39.3 L196.2,39.9 L194.7,40.6 L193.2,41.7 L191.7,42.9 L190.2,44.3 L188.8,45.8 L187.4,47.4 L186,49.1 L184.6,50.8 L183.2,52.4 L184.3,52.5 L185.2,52.6 L186,52.6 L186.7,52.7 L187.4,52.9 L188.1,53 L189,53.1 L190.1,53.3 L191.3,51.7 L192.4,50.3 L193.7,49 L194.8,47.9 L196.1,47 L197.2,46.1 L198.3,45.4 L199.5,44.9 L200.6,44.4 L201.6,44 L202.8,43.8 L203.8,43.5 L204.8,43.4 L205.8,43.3 L206.8,43.3 L207.7,43.3 Z" stroke-width="0.254" fill="url(#linearGradient-20)"></path>
-            <path d="M214.5,44.8 L214.5,44.8 L212.6,44.1 L210.8,43.6 L209,43.3 L207.3,43.2 L205.6,43.2 L204,43.5 L202.4,43.8 L200.9,44.3 L199.4,45 L198,45.8 L196.5,46.7 L195.2,47.8 L193.8,48.9 L192.6,50.2 L191.3,51.6 L190.1,53.1 L191.3,53.3 L192.7,53.5 L194.1,53.7 L195.5,53.8 L196.8,54 L197.8,54.1 L198.6,54.2 L198.9,54.2 L199,54.1 L199.3,53.8 L199.7,53.4 L200.2,52.9 L200.8,52.3 L201.6,51.6 L202.5,50.9 L203.5,50 L204.6,49.3 L205.7,48.5 L207,47.7 L208.4,47 L209.8,46.3 L211.3,45.7 L212.9,45.2 L214.5,44.8 Z" stroke-width="0.254" fill="url(#linearGradient-21)"></path>
-            <path d="M223.1,45.9 L223.1,45.9 L221.6,45.3 L220,44.8 L218.3,44.6 L216.7,44.6 L215,44.8 L213.3,45.1 L211.7,45.7 L210,46.3 L208.4,47.1 L206.8,47.9 L205.3,48.9 L203.8,49.9 L202.5,50.9 L201.1,52 L199.9,53.1 L198.8,54.2 L199.6,54.3 L200.5,54.4 L201.5,54.5 L202.6,54.6 L203.8,54.8 L204.7,54.9 L205.6,54.9 L206.3,54.9 L206.3,54.8 L206.5,54.5 L207.1,54.1 L208,53.5 L209,52.9 L210.3,52.1 L211.7,51.3 L213.1,50.5 L214.6,49.7 L216.1,48.9 L217.6,48.1 L219,47.4 L220.3,46.8 L221.4,46.4 L222.4,46.1 L223.1,45.9 Z" stroke-width="0.254" fill="url(#linearGradient-22)"></path>
-            <path d="M231.3,47.6 L231.3,47.6 L230.5,46.3 L229.3,45.5 L227.7,45.3 L226,45.3 L224.1,45.7 L222,46.3 L219.8,47.2 L217.6,48.2 L215.4,49.3 L213.4,50.4 L211.4,51.6 L209.7,52.7 L208.2,53.6 L207.1,54.3 L206.4,54.8 L206,55 L206.8,55.2 L207.8,55.3 L208.8,55.4 L209.8,55.5 L210.9,55.6 L212,55.7 L213.1,55.9 L214.1,56 L215.2,55.5 L216.3,55 L217.4,54.4 L218.4,53.8 L219.5,53.3 L220.5,52.7 L221.6,52.1 L222.7,51.5 L223.7,51 L224.8,50.4 L225.9,49.9 L226.9,49.4 L228,48.9 L229.1,48.5 L230.2,48 L231.3,47.6 Z" stroke-width="0.254" fill="url(#linearGradient-23)"></path>
-            <path d="M241.7,50.4 L241.7,50.4 L240.4,49.4 L239,48.9 L237.5,48.7 L235.8,48.7 L234.1,49 L232.4,49.5 L230.7,50.1 L229,50.9 L227.5,51.8 L225.9,52.6 L224.5,53.6 L223.3,54.4 L222.2,55.2 L221.3,55.9 L220.6,56.3 L220.3,56.6 L221.2,56.7 L222.1,56.8 L222.9,57 L223.6,57 L224.4,57.1 L225.2,57.2 L226.1,57.3 L227,57.4 L227.8,56.9 L228.6,56.4 L229.5,55.7 L230.4,55.1 L231.3,54.5 L232.2,53.9 L233.2,53.2 L234.1,52.6 L235,52.1 L236,51.6 L237,51.1 L237.9,50.8 L238.9,50.5 L239.9,50.3 L240.8,50.3 L241.7,50.4 Z" stroke-width="0.254" fill="url(#linearGradient-24)"></path>
-            <path d="M237.9,48.7 L237.9,48.7 L236.9,48 L235.8,47.6 L234.8,47.3 L233.8,47.2 L232.8,47.3 L231.6,47.5 L230.4,47.9 L229.1,48.4 L227.7,49 L226.3,49.7 L224.7,50.6 L222.9,51.5 L221,52.5 L218.9,53.6 L216.6,54.7 L214.1,55.9 L215.1,56 L216.1,56.1 L217.1,56.2 L218.2,56.4 L219.1,56.5 L219.8,56.6 L220.4,56.7 L220.6,56.6 L220.7,56.5 L221.1,56.2 L221.6,55.7 L222.3,55.2 L223.2,54.6 L224.3,53.9 L225.4,53.1 L226.6,52.4 L227.9,51.6 L229.3,50.8 L230.7,50.2 L232.2,49.6 L233.6,49.1 L235.1,48.8 L236.5,48.7 L237.9,48.7 Z" stroke-width="0.254" fill="url(#linearGradient-25)"></path>
-            <path d="M246.4,53.3 L246.4,53.3 L245.3,52.2 L244.2,51.3 L243.1,50.7 L242,50.4 L240.8,50.3 L239.6,50.4 L238.3,50.7 L237.1,51.1 L235.8,51.8 L234.6,52.4 L233.3,53.2 L232,54 L230.7,54.9 L229.5,55.7 L228.3,56.6 L227.1,57.4 L227.7,57.5 L228.5,57.5 L229.4,57.7 L230.3,57.8 L231.3,57.9 L232.4,58.1 L233.3,58.2 L234.3,58.3 L234.7,57.5 L235.1,56.9 L235.6,56.2 L236.1,55.7 L236.7,55.1 L237.4,54.7 L238.1,54.3 L238.9,54 L239.7,53.7 L240.6,53.4 L241.4,53.3 L242.4,53.2 L243.4,53.1 L244.3,53.1 L245.3,53.2 L246.4,53.3 Z" stroke-width="0.254" fill="url(#linearGradient-26)"></path>
-            <path d="M253.6,57.2 L253.6,57.2 L253.3,56.7 L252.8,56.3 L252.2,55.9 L251.5,55.7 L250.6,55.5 L249.7,55.5 L248.8,55.5 L247.7,55.5 L246.7,55.7 L245.7,56 L244.7,56.3 L243.8,56.7 L242.9,57.2 L242.1,57.8 L241.4,58.4 L240.9,59.1 L241.4,59.2 L242,59.3 L242.7,59.4 L243.3,59.6 L243.9,59.6 L244.4,59.7 L244.7,59.7 L244.8,59.7 L245.1,59.6 L245.6,59.2 L246.6,58.7 L247.8,58.2 L249.1,57.8 L250.6,57.3 L252.1,57.1 L253.6,57.2 Z" stroke-width="0.254" fill="url(#linearGradient-27)"></path>
-            <path d="M255,59.6 L255,59.6 L255,58.6 L254.8,57.9 L254.4,57.5 L253.7,57.2 L253,57 L252.1,57.1 L251.2,57.2 L250.1,57.5 L249.1,57.8 L248.1,58.2 L247.2,58.5 L246.4,58.9 L245.7,59.2 L245.1,59.4 L244.8,59.7 L244.7,59.7 L249.4,60.5 L249.8,60.4 L250.4,60.2 L251.1,60 L251.9,59.7 L252.7,59.6 L253.6,59.4 L254.3,59.4 L255,59.6 Z" stroke-width="0.254" fill="url(#linearGradient-28)"></path>
-            <path d="M251.1,55.7 L251.1,55.7 L250.2,54.9 L249.2,54.3 L248.1,53.8 L246.9,53.4 L245.6,53.2 L244.4,53 L243.1,53 L241.8,53.2 L240.6,53.4 L239.4,53.8 L238.3,54.3 L237.2,54.8 L236.3,55.6 L235.4,56.4 L234.8,57.3 L234.3,58.3 L235,58.4 L235.7,58.5 L236.5,58.6 L237.3,58.7 L238.1,58.8 L239,58.9 L239.9,59 L240.9,59.2 L241.3,58.6 L241.7,58.2 L242.1,57.8 L242.7,57.4 L243.2,57 L243.9,56.7 L244.5,56.4 L245.2,56.1 L245.9,55.9 L246.7,55.7 L247.4,55.6 L248.1,55.5 L248.9,55.5 L249.6,55.5 L250.4,55.5 L251.1,55.7 Z" stroke-width="0.254" fill="url(#linearGradient-29)"></path>
-            <path d="M43.7,27.8 L43.7,27.8 L43.6,28 L43.3,28.4 L42.9,29.2 L42.4,30.1 L41.8,31.2 L41.2,32.5 L40.7,33.9 L40.2,35.3 L39.9,36.7 L39.8,38.1 L39.8,39.5 L40.1,40.8 L40.8,42 L41.8,43 L43.2,43.8 L45,44.4 L44.7,43.5 L44.5,42.6 L44.3,41.7 L44.2,40.6 L44.1,39.6 L44.1,38.5 L44.2,37.4 L44.3,36.3 L44.4,35.2 L44.5,34.1 L44.7,33 L44.9,32 L45.1,31.1 L45.3,30.2 L45.6,29.3 L45.8,28.6 L45.5,28.4 L45.3,28.4 L45,28.3 L44.8,28.2 L44.5,28.1 L44.3,28 L44,27.9 L43.7,27.8 Z" stroke-width="0.254" fill="url(#linearGradient-30)"></path>
-            <path d="M45.7,28.6 L45.7,28.6 L44.9,31.8 L44.3,34.7 L44,37.2 L44,39.4 L44.1,41.4 L44.4,43 L44.9,44.4 L45.4,45.6 L46.1,46.5 L46.9,47.2 L47.6,47.8 L48.4,48.2 L49.2,48.5 L49.9,48.6 L50.6,48.6 L51.1,48.6 L50.8,47.7 L50.4,46.8 L50.1,45.7 L49.9,44.7 L49.7,43.5 L49.5,42.4 L49.3,41.2 L49.2,40 L49.1,38.7 L49.1,37.5 L49.2,36.2 L49.3,35 L49.5,33.7 L49.7,32.5 L50,31.3 L50.4,30.1 L49.7,29.8 L49,29.6 L48.3,29.4 L47.7,29.2 L47.2,29 L46.6,28.8 L46.1,28.7 L45.7,28.6 Z" stroke-width="0.254" fill="url(#linearGradient-31)"></path>
-            <path d="M50.4,30.1 L50.4,30.1 L50.1,31.2 L49.7,32.7 L49.5,34.3 L49.4,36.1 L49.3,38.1 L49.3,40.1 L49.5,42.1 L49.8,44 L50.2,45.8 L50.7,47.5 L51.5,48.9 L52.4,50.1 L53.5,51 L54.8,51.4 L56.2,51.5 L57.9,51 L57.3,50 L56.6,48.9 L56.1,47.7 L55.6,46.6 L55.3,45.4 L54.9,44.2 L54.7,43 L54.5,41.8 L54.3,40.5 L54.3,39.3 L54.3,38 L54.4,36.8 L54.5,35.5 L54.7,34.3 L55,33 L55.3,31.7 L54.7,31.5 L54,31.3 L53.3,31.1 L52.6,30.8 L51.9,30.6 L51.4,30.4 L50.8,30.2 L50.4,30.1 Z" stroke-width="0.254" fill="url(#linearGradient-32)"></path>
-            <path d="M65.2,54.2 L65.2,54.2 L63.7,54.3 L62.1,54.1 L60.8,53.5 L59.6,52.7 L58.4,51.6 L57.4,50.3 L56.6,48.8 L55.9,47.1 L55.3,45.3 L54.8,43.3 L54.5,41.4 L54.4,39.4 L54.4,37.4 L54.6,35.4 L54.9,33.5 L55.4,31.7 L56.1,31.9 L56.7,32.2 L57.4,32.3 L58.1,32.6 L58.8,32.8 L59.6,33 L60.3,33.3 L61,33.5 L61,34.7 L61,36.1 L61.1,37.6 L61.1,39.1 L61.2,40.7 L61.3,42.3 L61.4,44 L61.6,45.6 L61.9,47.2 L62.1,48.6 L62.4,50 L62.8,51.3 L63.3,52.3 L63.9,53.2 L64.5,53.8 L65.2,54.2 Z" stroke-width="0.254" fill="url(#linearGradient-33)"></path>
-            <path d="M61.1,33.5 L61.1,33.5 L61.7,33.8 L62.3,34 L62.8,34.1 L63.4,34.2 L63.9,34.4 L64.5,34.6 L65.1,34.8 L65.6,35 L65.7,36.2 L65.8,37.4 L65.9,38.8 L65.9,40.3 L65.9,41.8 L65.9,43.3 L66,44.9 L66,46.4 L66.2,47.9 L66.3,49.4 L66.6,50.8 L66.9,52.1 L67.4,53.3 L67.9,54.5 L68.6,55.4 L69.4,56.1 L67.7,55.7 L66.3,55.2 L65.1,54.3 L64.1,53.4 L63.3,52.3 L62.7,51 L62.2,49.6 L61.9,48.2 L61.6,46.5 L61.4,44.8 L61.4,43.1 L61.3,41.2 L61.3,39.4 L61.2,37.5 L61.2,35.5 L61.1,33.5 Z" stroke-width="0.254" fill="url(#linearGradient-34)"></path>
-            <path d="M76.5,58.4 L76.5,58.4 L74.2,58.3 L72.2,57.8 L70.6,57.1 L69.3,56.1 L68.2,54.8 L67.4,53.3 L66.8,51.7 L66.4,49.9 L66.2,48 L66,46.1 L65.9,44.1 L65.9,42.2 L65.9,40.2 L65.9,38.4 L65.8,36.6 L65.7,35 L66.3,35.2 L66.9,35.3 L67.4,35.5 L68,35.7 L68.6,35.9 L69.1,36 L69.7,36.2 L70.4,36.3 L70.3,36.5 L70.2,36.9 L70.1,37.6 L69.9,38.4 L69.8,39.4 L69.7,40.6 L69.6,41.9 L69.7,43.4 L69.8,45 L70.1,46.8 L70.7,48.6 L71.3,50.4 L72.2,52.4 L73.4,54.4 L74.8,56.4 L76.5,58.4 Z" stroke-width="0.254" fill="url(#linearGradient-35)"></path>
-            <path d="M84.5,60.9 L84.5,60.9 L82.9,61.2 L81.3,61.1 L79.8,60.6 L78.3,59.7 L76.8,58.6 L75.4,57.3 L74.2,55.7 L73,53.9 L72,51.9 L71.1,49.8 L70.4,47.6 L69.9,45.4 L69.7,43.1 L69.6,40.8 L69.8,38.6 L70.3,36.3 L75.8,38.1 L75.8,39 L75.7,40.1 L75.8,41.3 L75.9,42.7 L76.1,44.2 L76.4,45.8 L76.6,47.4 L77.1,49.1 L77.6,50.8 L78.3,52.4 L79,54 L79.9,55.6 L80.8,57.1 L81.9,58.5 L83.1,59.8 L84.5,60.9 Z" stroke-width="0.254" fill="url(#linearGradient-36)"></path>
-            <path d="M75.7,38 L75.7,38 L76.6,38.3 L77.7,38.5 L78.9,39 L80.2,39.3 L81.4,39.7 L82.6,40.1 L83.7,40.3 L84.5,40.5 L84.6,41.9 L84.7,43.3 L84.8,44.8 L84.9,46.3 L85,47.8 L85.2,49.4 L85.3,50.9 L85.6,52.4 L85.9,53.9 L86.2,55.3 L86.7,56.7 L87.2,57.9 L87.8,59.2 L88.6,60.2 L89.4,61.2 L90.4,62.1 L89.2,62.2 L88,62.2 L86.8,61.9 L85.6,61.4 L84.3,60.6 L83.1,59.7 L82,58.5 L80.8,57.1 L79.7,55.5 L78.8,53.6 L77.9,51.6 L77.2,49.3 L76.6,46.8 L76.1,44.1 L75.8,41.1 L75.7,38 Z" stroke-width="0.254" fill="url(#linearGradient-37)"></path>
-            <path d="M98,63.2 L98,63.2 L95.4,63.3 L93.2,63.1 L91.3,62.5 L89.8,61.5 L88.5,60.3 L87.4,58.8 L86.7,57.2 L86.1,55.3 L85.6,53.5 L85.3,51.4 L85.2,49.4 L85,47.5 L84.9,45.5 L84.8,43.7 L84.7,42 L84.5,40.5 L85.3,40.6 L86,40.8 L86.7,41 L87.3,41.2 L88,41.4 L88.6,41.6 L89.4,41.8 L90.3,42 L90.5,43.6 L90.6,45.1 L90.8,46.6 L91,48.1 L91.2,49.5 L91.4,50.9 L91.7,52.3 L92,53.6 L92.4,54.9 L92.9,56.2 L93.5,57.4 L94.1,58.6 L94.9,59.8 L95.8,61 L96.9,62.1 L98,63.2 Z" stroke-width="0.254" fill="url(#linearGradient-38)"></path>
-            <path d="M105.1,64.5 L105.1,64.5 L102.8,64.6 L100.7,64.3 L98.9,63.7 L97.3,62.7 L96,61.5 L94.8,60 L93.9,58.3 L93.1,56.5 L92.4,54.7 L91.9,52.7 L91.4,50.8 L91.2,48.8 L90.9,46.9 L90.7,45.2 L90.5,43.5 L90.4,42.1 L91.2,42.3 L91.9,42.5 L92.5,42.7 L93.2,42.8 L93.8,43 L94.4,43.1 L95.2,43.3 L96,43.5 L96.3,45.8 L96.7,47.9 L97.1,49.9 L97.5,51.8 L98,53.4 L98.5,55.1 L99.1,56.5 L99.7,57.8 L100.2,59 L100.9,60.1 L101.6,61.1 L102.2,61.9 L102.9,62.8 L103.6,63.4 L104.4,64 L105.1,64.5 Z" stroke-width="0.254" fill="url(#linearGradient-39)"></path>
-            <path d="M111.7,65.4 L111.7,65.4 L109.5,65.5 L107.5,65.2 L105.8,64.6 L104.2,63.6 L102.8,62.4 L101.6,61 L100.5,59.4 L99.6,57.6 L98.8,55.8 L98.1,53.9 L97.6,52 L97.2,50.1 L96.7,48.3 L96.5,46.5 L96.2,44.9 L96,43.5 L96.7,43.7 L97.4,43.8 L98.1,44 L98.8,44.2 L99.5,44.4 L100.2,44.5 L100.9,44.7 L101.6,44.9 L101.7,46 L101.9,47.2 L102.1,48.5 L102.5,49.9 L102.9,51.4 L103.5,52.9 L104.1,54.4 L104.7,55.9 L105.5,57.5 L106.3,58.9 L107.1,60.3 L108,61.5 L108.9,62.8 L109.8,63.8 L110.8,64.7 L111.7,65.4 Z" stroke-width="0.254" fill="url(#linearGradient-40)"></path>
-            <path d="M119,66.7 L119,66.7 L116.7,67 L114.6,66.7 L112.7,66 L111,64.8 L109.3,63.3 L107.9,61.6 L106.7,59.6 L105.5,57.6 L104.6,55.4 L103.7,53.3 L103,51.3 L102.5,49.4 L102.1,47.8 L101.8,46.4 L101.6,45.5 L101.6,44.9 L102.5,45 L103.3,45.2 L104.1,45.5 L105,45.6 L105.8,45.9 L106.5,46 L107.3,46.2 L108,46.3 L108.3,47.3 L108.6,48.5 L109,49.8 L109.4,51.3 L109.9,52.9 L110.4,54.5 L111,56.2 L111.6,57.9 L112.3,59.5 L113.1,61 L113.9,62.5 L114.8,63.7 L115.7,64.8 L116.7,65.7 L117.8,66.4 L119,66.7 Z" stroke-width="0.254" fill="url(#linearGradient-41)"></path>
-            <path d="M124.3,66.4 L124.3,66.4 L122.2,66.9 L120.4,66.9 L118.7,66.5 L117.1,65.7 L115.7,64.6 L114.5,63.2 L113.4,61.6 L112.4,59.8 L111.6,58 L110.8,56.1 L110.3,54.1 L109.7,52.3 L109.2,50.5 L108.9,48.9 L108.5,47.5 L108.2,46.4 L108.9,46.6 L109.5,46.6 L110.1,46.7 L110.6,46.8 L111.2,47 L111.7,47.1 L112.2,47.2 L112.7,47.3 L112.9,48.6 L113.2,50 L113.5,51.4 L113.9,52.7 L114.3,54.1 L114.9,55.5 L115.4,56.8 L116.1,58 L116.8,59.3 L117.7,60.5 L118.6,61.7 L119.5,62.7 L120.6,63.8 L121.7,64.7 L123,65.6 L124.3,66.4 Z" stroke-width="0.254" fill="url(#linearGradient-42)"></path>
-            <path d="M131,67.5 L131,67.5 L129.2,67.5 L127.5,67.3 L125.9,66.9 L124.3,66.3 L122.9,65.5 L121.4,64.5 L120.1,63.3 L118.8,62 L117.7,60.6 L116.7,59 L115.7,57.3 L114.9,55.5 L114.2,53.5 L113.6,51.5 L113.1,49.4 L112.7,47.3 L113.5,47.4 L114.2,47.5 L115,47.7 L115.8,47.8 L116.5,48 L117.2,48.1 L118,48.2 L118.7,48.4 L119.1,49.6 L119.3,50.9 L119.7,52.1 L120,53.4 L120.3,54.6 L120.7,55.8 L121.2,57 L121.7,58.2 L122.3,59.4 L123,60.6 L123.9,61.8 L124.9,62.9 L126.1,64 L127.5,65.2 L129.1,66.4 L131,67.5 Z" stroke-width="0.254" fill="url(#linearGradient-43)"></path>
-            <path d="M140.4,68.6 L140.4,68.6 L138.1,68.7 L135.9,68.6 L133.9,68.3 L131.9,67.7 L130.1,66.9 L128.4,65.9 L126.9,64.8 L125.5,63.4 L124.2,61.9 L123,60.3 L122,58.5 L121.1,56.7 L120.3,54.7 L119.7,52.7 L119.2,50.6 L118.9,48.5 L119.5,48.6 L120.2,48.8 L120.9,48.9 L121.6,49 L122.3,49.1 L123.1,49.3 L123.8,49.4 L124.6,49.6 L124.8,51 L125.2,52.5 L125.6,53.9 L126.2,55.3 L126.9,56.7 L127.7,58.1 L128.6,59.5 L129.5,60.8 L130.6,62 L131.8,63.2 L133,64.3 L134.3,65.4 L135.7,66.3 L137.2,67.2 L138.8,67.9 L140.4,68.6 Z" stroke-width="0.254" fill="url(#linearGradient-44)"></path>
-            <path d="M145.6,69.1 L145.6,69.1 L143.6,69 L141.8,68.7 L139.9,68.3 L138.1,67.6 L136.4,66.7 L134.7,65.8 L133.2,64.7 L131.7,63.4 L130.4,62 L129.1,60.5 L128,58.8 L127,57.1 L126.2,55.3 L125.5,53.5 L124.9,51.6 L124.6,49.6 L125.2,49.7 L125.8,49.7 L126.3,49.8 L126.9,49.9 L127.4,49.9 L128,50 L128.7,50.2 L129.5,50.3 L130.3,52 L131,53.5 L131.7,55 L132.3,56.4 L133,57.8 L133.7,59 L134.4,60.2 L135.1,61.3 L136,62.4 L136.9,63.4 L137.9,64.4 L139.1,65.4 L140.4,66.3 L142,67.3 L143.6,68.2 L145.6,69.1 Z" stroke-width="0.254" fill="url(#linearGradient-45)"></path>
-            <path d="M154.9,69.7 L154.9,69.7 L152,69.8 L149.4,69.7 L147,69.3 L144.8,68.7 L142.7,67.8 L140.9,66.7 L139.2,65.5 L137.7,64.1 L136.3,62.6 L135,61 L133.9,59.3 L132.9,57.5 L131.9,55.7 L131,53.9 L130.2,52 L129.4,50.2 L129.9,50.3 L130.6,50.4 L131.5,50.5 L132.4,50.6 L133.3,50.8 L134.1,50.9 L134.8,51 L135.4,51.1 L136.1,52.7 L136.8,54.3 L137.7,55.9 L138.6,57.3 L139.6,58.7 L140.6,60 L141.7,61.2 L142.9,62.4 L144.2,63.5 L145.5,64.6 L146.9,65.6 L148.4,66.6 L149.9,67.4 L151.5,68.3 L153.1,69 L154.9,69.7 Z" stroke-width="0.254" fill="url(#linearGradient-46)"></path>
-            <path d="M160.4,70.5 L160.4,70.5 L158.9,70.5 L157.2,70.2 L155.5,69.8 L153.7,69.2 L151.9,68.4 L150.1,67.5 L148.2,66.4 L146.4,65.2 L144.7,63.8 L143,62.3 L141.4,60.7 L139.9,58.9 L138.6,57.1 L137.4,55.2 L136.3,53.2 L135.4,51.1 L136.3,51.2 L137.2,51.3 L138.1,51.4 L139,51.5 L139.8,51.5 L140.5,51.7 L141.1,51.8 L141.4,52 L142.5,52.8 L143.5,53.6 L144.6,54.7 L145.7,55.7 L146.8,56.9 L148,58.1 L149.2,59.4 L150.3,60.7 L151.5,62 L152.7,63.3 L154,64.6 L155.2,65.9 L156.5,67.1 L157.8,68.3 L159.1,69.5 L160.4,70.5 Z" stroke-width="0.254" fill="url(#linearGradient-47)"></path>
-            <path d="M168.9,70.5 L168.9,70.5 L167.4,71.5 L165.8,71.9 L164.3,71.9 L162.6,71.5 L161,70.7 L159.4,69.6 L157.7,68.2 L156,66.6 L154.3,64.8 L152.6,63 L150.7,61 L148.9,59 L147.1,57.1 L145.3,55.2 L143.4,53.4 L141.5,51.8 L142.2,51.8 L142.9,52 L143.8,52 L144.7,52.2 L145.6,52.3 L146.6,52.5 L147.4,52.6 L148.2,52.8 L149.6,54.1 L151.1,55.4 L152.5,56.8 L153.9,58.2 L155.2,59.6 L156.6,61 L157.9,62.4 L159.2,63.7 L160.5,65 L161.8,66.2 L163,67.2 L164.2,68.1 L165.4,68.9 L166.6,69.6 L167.8,70.2 L168.9,70.5 Z" stroke-width="0.254" fill="url(#linearGradient-48)"></path>
-            <path d="M175.5,71.3 L175.5,71.3 L173.1,71.3 L170.9,71 L168.8,70.5 L166.8,69.7 L165,68.8 L163.3,67.6 L161.7,66.3 L160.2,64.9 L158.7,63.4 L157.2,61.8 L155.8,60.3 L154.4,58.6 L152.9,57 L151.4,55.4 L149.8,54 L148.2,52.6 L148.8,52.6 L149.5,52.7 L150.3,52.8 L151.2,52.9 L152.1,53 L152.8,53 L153.4,53.1 L153.7,53.1 L154.7,53.3 L155.7,53.8 L156.7,54.4 L157.7,55.3 L158.8,56.4 L159.9,57.6 L161.1,58.9 L162.2,60.3 L163.6,61.7 L164.9,63.2 L166.4,64.7 L168,66.1 L169.7,67.6 L171.5,68.9 L173.4,70.2 L175.5,71.3 Z" stroke-width="0.254" fill="url(#linearGradient-49)"></path>
-            <path d="M45.9,23.3 L45.9,23.3 L45.9,23.1 L45.8,22.4 L45.8,21.4 L45.7,20.2 L45.6,18.8 L45.7,17.2 L45.8,15.6 L45.9,13.9 L46.3,12.3 L46.7,10.8 L47.3,9.4 L48.2,8.3 L49.2,7.5 L50.5,7.1 L52,7 L53.8,7.5 L53.3,8 L52.7,8.7 L52.2,9.6 L51.7,10.5 L51.3,11.6 L50.9,12.6 L50.5,13.8 L50.1,15 L49.7,16.2 L49.4,17.4 L49.1,18.6 L48.8,19.8 L48.6,21 L48.4,22.1 L48.2,23.1 L48,24 L47.7,24 L47.5,23.9 L47.2,23.8 L47,23.7 L46.8,23.6 L46.5,23.5 L46.2,23.4 L45.9,23.3 Z" stroke-width="0.254" fill="url(#linearGradient-50)"></path>
-            <path d="M48,24.2 L48,24.2 L48.8,20.4 L49.6,17.2 L50.4,14.5 L51.2,12.2 L52,10.4 L52.9,8.9 L53.7,7.9 L54.4,7.1 L55.2,6.6 L55.9,6.4 L56.7,6.3 L57.3,6.4 L58,6.6 L58.6,6.9 L59.1,7.3 L59.6,7.6 L58.7,8.4 L57.9,9.3 L57.2,10.1 L56.5,11 L55.8,11.9 L55.2,12.9 L54.6,13.9 L54.1,15 L53.6,16.1 L53.1,17.2 L52.6,18.4 L52.2,19.6 L51.9,20.9 L51.5,22.2 L51.2,23.5 L50.9,24.9 L50.2,24.8 L49.7,24.8 L49.3,24.6 L49.1,24.5 L48.8,24.5 L48.6,24.4 L48.4,24.3 L48,24.2 Z" stroke-width="0.254" fill="url(#linearGradient-51)"></path>
-            <path d="M50.9,25.3 L50.9,25.3 L51.1,23.9 L51.4,22.3 L51.9,20.6 L52.5,18.7 L53.2,16.8 L54.1,14.9 L55,13.1 L56.1,11.4 L57.2,9.9 L58.3,8.6 L59.6,7.6 L60.8,7 L62.2,6.8 L63.5,7 L64.8,7.7 L66.1,9.1 L65.1,9.8 L64.1,10.7 L63.2,11.6 L62.3,12.5 L61.4,13.4 L60.7,14.4 L60,15.5 L59.3,16.5 L58.7,17.7 L58.2,18.9 L57.6,20.1 L57.2,21.4 L56.8,22.7 L56.5,24.1 L56.2,25.6 L56,27.1 L55.4,26.9 L54.7,26.7 L53.9,26.4 L53.2,26.2 L52.5,25.9 L51.8,25.6 L51.3,25.4 L50.9,25.3 Z" stroke-width="0.254" fill="url(#linearGradient-52)"></path>
-            <path d="M73.7,10 L73.7,10 L72.3,9.1 L70.9,8.6 L69.4,8.4 L68,8.6 L66.5,9 L65.1,9.8 L63.8,10.8 L62.5,12.1 L61.4,13.5 L60.2,15.1 L59.2,16.9 L58.3,18.8 L57.6,20.7 L57,22.8 L56.5,24.9 L56.3,27.1 L57,27.3 L57.7,27.4 L58.4,27.7 L59.1,27.9 L59.9,28.2 L60.6,28.4 L61.3,28.6 L62.1,28.7 L62.6,27.4 L63.1,25.9 L63.6,24.5 L64.2,23 L64.7,21.5 L65.4,20 L66,18.5 L66.7,17.1 L67.4,15.8 L68.1,14.6 L68.9,13.4 L69.8,12.4 L70.7,11.5 L71.6,10.8 L72.6,10.3 L73.7,10 Z" stroke-width="0.254" fill="url(#linearGradient-53)"></path>
-            <path d="M80.1,11.7 L80.1,11.7 L77.8,10.8 L75.9,10.2 L74.1,10.2 L72.5,10.5 L71.1,11.1 L69.9,12.1 L68.8,13.3 L67.8,14.8 L67,16.4 L66.2,18.2 L65.4,20.1 L64.7,22 L64.1,23.9 L63.4,25.8 L62.7,27.6 L62,29.3 L62.6,29.4 L63.2,29.5 L63.8,29.7 L64.3,29.9 L64.9,30.1 L65.5,30.3 L66.2,30.5 L66.8,30.6 L66.9,30.4 L66.9,29.8 L67.1,29.1 L67.3,28 L67.5,26.8 L68,25.4 L68.4,23.9 L69.1,22.3 L69.8,20.7 L70.7,19.2 L71.8,17.6 L73,16.1 L74.5,14.7 L76.1,13.6 L78,12.5 L80.1,11.7 Z" stroke-width="0.254" fill="url(#linearGradient-54)"></path>
-            <path d="M88.3,13 L88.3,13 L87,12 L85.5,11.3 L83.8,11.1 L82.2,11.2 L80.5,11.5 L78.7,12.2 L77,13.2 L75.3,14.3 L73.7,15.8 L72.2,17.4 L70.9,19.3 L69.6,21.3 L68.6,23.5 L67.8,25.8 L67.3,28.2 L67,30.8 L73,32.3 L73.3,31.3 L73.8,30.2 L74.2,28.9 L74.8,27.6 L75.5,26.2 L76.2,24.7 L77,23.3 L77.9,21.8 L78.9,20.4 L80,19 L81.2,17.7 L82.4,16.5 L83.7,15.4 L85.2,14.4 L86.7,13.6 L88.3,13 Z" stroke-width="0.254" fill="url(#linearGradient-55)"></path>
-            <path d="M72.9,32.5 L72.9,32.5 L73.8,32.7 L74.9,32.9 L76,33.2 L77.2,33.6 L78.4,34 L79.5,34.3 L80.5,34.6 L81.5,34.9 L81.3,34.8 L82.1,33.4 L82.8,31.9 L83.4,30.4 L84,28.8 L84.7,27.2 L85.3,25.8 L85.9,24.2 L86.7,22.6 L87.5,21.2 L88.3,20 L89.3,18.7 L90.3,17.6 L91.2,16.6 L92.4,15.8 L93.6,15.2 L94.8,14.7 L93.7,14 L92.6,13.5 L91.4,13.1 L90,13 L88.6,13.1 L87.2,13.5 L85.7,14.1 L84.2,15 L82.7,16.1 L81.2,17.5 L79.7,19.2 L78.2,21.2 L76.8,23.5 L75.4,26.1 L74.1,29.2 L72.9,32.5 Z" stroke-width="0.254" fill="url(#linearGradient-56)"></path>
-            <path d="M102.1,17.2 L102.1,17.2 L99.7,15.9 L97.6,15.2 L95.6,15 L93.8,15.3 L92.2,16 L90.7,17 L89.4,18.4 L88.2,20 L87.2,21.8 L86.2,23.7 L85.3,25.8 L84.5,27.8 L83.7,29.8 L82.9,31.7 L82.2,33.5 L81.5,35 L82.3,35.2 L83,35.3 L83.7,35.5 L84.3,35.6 L85,35.8 L85.7,36 L86.4,36.1 L87.3,36.3 L88.1,34.7 L88.8,33.1 L89.5,31.6 L90.2,30.1 L90.8,28.7 L91.6,27.4 L92.4,26 L93.1,24.8 L94,23.6 L94.9,22.5 L95.8,21.4 L96.9,20.4 L98.1,19.5 L99.3,18.7 L100.7,17.9 L102.1,17.2 Z" stroke-width="0.254" fill="url(#linearGradient-57)"></path>
-            <path d="M109.4,19.3 L109.4,19.3 L107.2,18.1 L105.2,17.6 L103.2,17.4 L101.4,17.7 L99.7,18.4 L98.1,19.5 L96.6,20.8 L95.2,22.3 L93.9,24 L92.7,25.8 L91.5,27.7 L90.6,29.6 L89.6,31.6 L88.8,33.3 L88.1,35 L87.5,36.4 L88.3,36.6 L89.1,36.8 L89.8,37 L90.4,37.1 L91.1,37.3 L91.8,37.4 L92.7,37.5 L93.6,37.7 L94.6,35.4 L95.7,33.2 L96.7,31.3 L97.7,29.4 L98.6,27.8 L99.5,26.4 L100.4,25.1 L101.3,23.8 L102.2,22.9 L103.1,22 L104.1,21.2 L105.1,20.6 L106,20.1 L107.1,19.7 L108.2,19.5 L109.4,19.3 Z" stroke-width="0.254" fill="url(#linearGradient-58)"></path>
-            <path d="M114.8,20.9 L114.8,20.9 L112.7,19.9 L110.8,19.4 L108.9,19.4 L107.1,19.8 L105.5,20.5 L103.9,21.5 L102.4,22.7 L101,24.2 L99.8,25.8 L98.7,27.6 L97.5,29.4 L96.6,31.2 L95.7,33 L94.9,34.7 L94.2,36.3 L93.6,37.8 L94.3,38 L94.9,38.1 L95.6,38.2 L96.2,38.4 L96.8,38.5 L97.4,38.6 L98.1,38.8 L98.9,38.9 L99.2,37.8 L99.8,36.5 L100.4,35.2 L101.2,33.8 L102,32.4 L103,31 L104,29.6 L105.1,28.2 L106.2,26.9 L107.4,25.6 L108.7,24.5 L109.9,23.5 L111.2,22.6 L112.4,21.8 L113.6,21.2 L114.8,20.9 Z" stroke-width="0.254" fill="url(#linearGradient-59)"></path>
-            <path d="M121.4,22.6 L121.4,22.6 L119.3,21.4 L117.2,20.9 L115.1,20.9 L113.1,21.5 L111.2,22.4 L109.3,23.8 L107.6,25.4 L105.9,27.1 L104.4,29 L103.1,30.9 L101.9,32.8 L100.9,34.6 L100.1,36.1 L99.4,37.5 L99.1,38.5 L98.9,39.1 L99.8,39.2 L100.5,39.4 L101.3,39.6 L102,39.8 L102.8,39.9 L103.5,40 L104.3,40.2 L105,40.3 L105.5,39.3 L106.1,38.1 L106.8,36.7 L107.6,35.3 L108.5,33.7 L109.4,32.2 L110.4,30.7 L111.5,29.1 L112.6,27.6 L113.7,26.3 L115,25.1 L116.2,24.1 L117.5,23.3 L118.7,22.7 L120.1,22.5 L121.4,22.6 Z" stroke-width="0.254" fill="url(#linearGradient-60)"></path>
-            <path d="M126.2,24.4 L126.2,24.4 L124.3,23.1 L122.4,22.4 L120.7,22.3 L118.9,22.6 L117.3,23.3 L115.7,24.3 L114.3,25.6 L112.9,27.2 L111.6,28.9 L110.4,30.7 L109.3,32.5 L108.2,34.4 L107.3,36.1 L106.5,37.8 L105.9,39.2 L105.3,40.3 L106,40.4 L106.6,40.6 L107.1,40.8 L107.6,41 L108.1,41.1 L108.6,41.3 L109,41.4 L109.6,41.5 L110.1,40.1 L110.7,38.6 L111.4,37.2 L112.1,35.8 L112.9,34.4 L113.7,33.2 L114.6,31.9 L115.6,30.7 L116.7,29.5 L117.8,28.4 L119,27.5 L120.3,26.6 L121.7,25.9 L123.1,25.2 L124.6,24.8 L126.2,24.4 Z" stroke-width="0.254" fill="url(#linearGradient-61)"></path>
-            <path d="M132.3,25.8 L132.3,25.8 L130.6,25.2 L128.9,24.8 L127.1,24.6 L125.5,24.8 L123.8,25.1 L122.2,25.6 L120.7,26.5 L119.1,27.4 L117.6,28.6 L116.2,30 L114.9,31.5 L113.6,33.2 L112.4,35.1 L111.4,37.1 L110.3,39.3 L109.4,41.5 L110.2,41.7 L111,41.8 L111.7,42 L112.5,42.2 L113.2,42.4 L114,42.6 L114.7,42.8 L115.5,42.9 L116,41.6 L116.5,40.3 L117.1,39 L117.6,37.6 L118.2,36.4 L118.9,35.1 L119.6,33.9 L120.4,32.7 L121.4,31.6 L122.5,30.5 L123.7,29.5 L125,28.5 L126.6,27.7 L128.2,27 L130.2,26.3 L132.3,25.8 Z" stroke-width="0.254" fill="url(#linearGradient-62)"></path>
-            <path d="M140.9,27.8 L140.9,27.8 L138.7,26.9 L136.5,26.3 L134.4,26 L132.4,26 L130.5,26.3 L128.6,26.8 L126.8,27.6 L125.2,28.5 L123.6,29.8 L122.1,31.2 L120.8,32.7 L119.5,34.5 L118.3,36.4 L117.4,38.5 L116.4,40.6 L115.6,42.8 L116.3,42.9 L117,43.1 L117.8,43.2 L118.6,43.3 L119.4,43.4 L120.2,43.5 L121,43.6 L121.8,43.8 L122.3,42.1 L122.8,40.6 L123.5,39.1 L124.3,37.6 L125.2,36.3 L126.2,35 L127.2,33.8 L128.4,32.7 L129.6,31.6 L131,30.8 L132.5,29.9 L134,29.2 L135.6,28.7 L137.3,28.2 L139.1,28 L140.9,27.8 Z" stroke-width="0.254" fill="url(#linearGradient-63)"></path>
-            <path d="M145.1,28.3 L145.1,28.3 L143.2,28 L141.2,27.8 L139.3,27.9 L137.4,28.1 L135.6,28.6 L133.8,29.2 L132.1,29.9 L130.5,30.9 L129,32 L127.5,33.3 L126.3,34.7 L125,36.2 L124,38 L123.1,39.9 L122.3,41.9 L121.7,44 L122.4,44.1 L123,44.2 L123.6,44.3 L124.2,44.4 L124.8,44.5 L125.3,44.6 L126,44.8 L126.8,44.9 L127.8,43.2 L128.7,41.6 L129.5,40.1 L130.3,38.7 L131.1,37.4 L131.9,36.2 L132.6,35 L133.5,34 L134.4,33 L135.5,32.1 L136.6,31.3 L137.9,30.5 L139.4,29.9 L141.1,29.3 L143,28.8 L145.1,28.3 Z" stroke-width="0.254" fill="url(#linearGradient-64)"></path>
-            <path d="M154.4,29.5 L154.4,29.5 L151.5,28.8 L148.7,28.4 L146.2,28.3 L143.9,28.5 L141.8,29 L139.8,29.7 L138,30.6 L136.3,31.7 L134.8,33 L133.4,34.5 L132.1,36.1 L130.9,37.8 L129.8,39.5 L128.7,41.4 L127.8,43.2 L126.9,45.1 L127.3,45.2 L128,45.3 L128.7,45.4 L129.4,45.6 L130.2,45.7 L130.9,45.9 L131.5,46 L132,46 L132.9,44.3 L133.8,42.7 L134.9,41.2 L136,39.8 L137.2,38.4 L138.4,37.2 L139.7,36.1 L141.1,35.1 L142.6,34.1 L144.1,33.3 L145.7,32.5 L147.3,31.7 L149,31.1 L150.7,30.5 L152.5,30 L154.4,29.5 Z" stroke-width="0.254" fill="url(#linearGradient-65)"></path>
-            <path d="M159.9,30.1 L159.9,30.1 L158.3,29.8 L156.6,29.7 L154.7,29.8 L152.8,30.1 L150.9,30.5 L148.9,31.1 L146.9,31.9 L145,32.8 L143,33.9 L141.1,35.2 L139.3,36.6 L137.6,38.2 L136,39.9 L134.5,41.8 L133.3,43.8 L132.2,46 L133,46.1 L133.8,46.2 L134.6,46.4 L135.4,46.5 L136.1,46.7 L136.7,46.9 L137.2,46.9 L137.5,46.9 L138.6,46.2 L139.8,45.4 L141,44.4 L142.3,43.4 L143.6,42.3 L144.9,41.1 L146.3,39.9 L147.7,38.7 L149.2,37.5 L150.6,36.3 L152.1,35.1 L153.6,33.9 L155.2,32.8 L156.7,31.8 L158.4,30.9 L159.9,30.1 Z" stroke-width="0.254" fill="url(#linearGradient-66)"></path>
-            <path d="M167.7,32.3 L167.7,32.3 L166.2,30.8 L164.6,30 L163,29.6 L161.3,29.7 L159.6,30.2 L157.7,31.1 L155.9,32.3 L153.9,33.6 L151.9,35.2 L149.9,36.9 L147.8,38.7 L145.8,40.5 L143.7,42.3 L141.6,44 L139.5,45.6 L137.4,47 L138,47.1 L138.8,47.2 L139.7,47.2 L140.7,47.3 L141.6,47.4 L142.6,47.4 L143.5,47.4 L144.3,47.3 L145.8,46.2 L147.4,45 L148.9,43.7 L150.3,42.5 L151.7,41.2 L153,40 L154.3,38.8 L155.7,37.6 L157.1,36.6 L158.4,35.6 L159.8,34.7 L161.3,33.9 L162.8,33.3 L164.4,32.8 L166,32.5 L167.7,32.3 Z" stroke-width="0.254" fill="url(#linearGradient-67)"></path>
-            <path d="M173.5,33 L173.5,33 L171.1,32.4 L168.8,32.2 L166.6,32.3 L164.6,32.7 L162.7,33.4 L160.8,34.3 L159,35.4 L157.3,36.6 L155.6,38 L153.9,39.4 L152.2,40.9 L150.6,42.5 L148.9,43.9 L147.2,45.4 L145.4,46.6 L143.6,47.9 L144.2,47.9 L144.9,48 L145.8,48.2 L146.7,48.2 L147.5,48.3 L148.3,48.5 L148.9,48.5 L149.2,48.6 L150.3,48.6 L151.3,48.3 L152.4,47.7 L153.6,47 L154.8,46.1 L156,45 L157.4,43.7 L158.8,42.4 L160.2,41.1 L161.8,39.7 L163.5,38.4 L165.2,37.1 L167.2,35.9 L169.1,34.7 L171.2,33.8 L173.5,33 Z" stroke-width="0.254" fill="url(#linearGradient-68)"></path>
-            <path d="M180.8,35 L180.8,35 L178.7,33.8 L176.4,33.3 L174.2,33.3 L171.9,33.8 L169.7,34.6 L167.4,35.9 L165.2,37.3 L163,38.9 L161,40.6 L159,42.4 L157.1,44 L155.3,45.5 L153.8,46.8 L152.3,47.8 L151,48.4 L149.9,48.6 L150.9,48.7 L151.8,48.9 L153,49 L154.1,49.2 L155.3,49.3 L156.4,49.5 L157.6,49.6 L158.5,49.6 L160.2,48.4 L161.6,47.2 L163,46.1 L164.2,44.9 L165.4,43.8 L166.5,42.7 L167.7,41.7 L168.8,40.7 L169.9,39.8 L171.1,38.9 L172.4,38.1 L173.8,37.3 L175.3,36.6 L176.9,36 L178.8,35.5 L180.8,35 Z" stroke-width="0.254" fill="url(#linearGradient-69)"></path>
-            <g transform="translate(19.000000, 0.000000)" stroke-width="0.254">
-                <path d="M20.7,11.1 L20.7,11.1 L20.5,10.6 L20.2,9.9 L20,9.3 L19.8,8.6 L19.6,7.9 L19.5,7.2 L19.4,6.5 L19.3,5.7 L19.2,5 L19.2,4.3 L19.2,3.5 L19.2,2.8 L19.3,2.1 L19.4,1.4 L19.6,0.7 L19.8,0.1 L18.8,1.3 L18.1,2.6 L17.6,3.9 L17.3,5.3 L17.2,6.7 L17.2,8.1 L17.4,9.5 L17.7,10.9 L18,12.2 L18.5,13.6 L19,14.9 L19.5,16.3 L20.1,17.5 L20.6,18.8 L21.2,20 L21.7,21.2 L21.6,20.9 L21.5,20.5 L21.5,20.1 L21.5,19.6 L21.4,18.9 L21.4,18.3 L21.4,17.6 L21.4,16.9 L21.3,16.1 L21.3,15.3 L21.3,14.5 L21.2,13.8 L21.2,13.1 L21,12.4 L20.9,11.7 L20.7,11.1 Z" fill="url(#linearGradient-70)"></path>
-                <path d="M3,35.3 L3,35.3 L4.1,34.7 L5.2,34 L6.3,33.3 L7.3,32.7 L8.3,32.1 L9.3,31.5 L10.2,30.9 L11.2,30.3 L12.1,29.7 L13.1,29.1 L14,28.4 L15,27.9 L15.9,27.3 L16.9,26.8 L18,26.2 L19,25.6 L18.1,26.5 L17.2,27.5 L16.2,28.4 L15.3,29.3 L14.3,30.2 L13.3,31 L12.3,31.8 L11.3,32.6 L10.3,33.3 L9.2,33.9 L8.2,34.4 L7.2,34.8 L6.2,35.2 L5.1,35.3 L4.1,35.4 L3,35.3 Z" fill="url(#linearGradient-71)"></path>
-                <path d="M11.7,12 L11.7,12 L12.5,12.5 L13.2,13 L14,13.5 L14.7,14.1 L15.4,14.6 L16,15.2 L16.7,15.8 L17.3,16.4 L17.9,17 L18.5,17.7 L19.1,18.3 L19.6,19 L20.2,19.6 L20.7,20.3 L21.2,21 L21.7,21.7 L21.5,21 L21.2,20.2 L20.9,19.4 L20.6,18.6 L20.2,17.8 L19.8,17 L19.4,16.3 L18.8,15.5 L18.3,14.8 L17.5,14.2 L16.8,13.6 L16,13.1 L15,12.7 L14.1,12.4 L12.9,12.1 L11.7,12 Z" fill="url(#linearGradient-72)"></path>
-                <path d="M20.3,5 L20.3,5 L20.6,6.2 L20.7,7.4 L21,8.5 L21.2,9.6 L21.3,10.7 L21.4,11.7 L21.6,12.8 L21.7,13.8 L21.9,14.9 L22,15.9 L22.1,16.9 L22.3,18 L22.5,19 L22.7,20.1 L22.9,21.1 L23.1,22.2 L23.3,20.9 L23.4,19.7 L23.6,18.4 L23.7,17.1 L23.7,15.9 L23.8,14.7 L23.7,13.5 L23.7,12.3 L23.5,11.1 L23.4,10.1 L23.1,9 L22.7,8.1 L22.3,7.2 L21.7,6.4 L21.1,5.7 L20.3,5 Z" fill="url(#linearGradient-73)"></path>
-                <path d="M14.1,3.1 L14.1,3.1 L13.1,4.1 L12.4,5.2 L12.1,6.4 L12.1,7.6 L12.3,8.8 L12.8,10.1 L13.4,11.4 L14.2,12.7 L15,13.9 L16,15.1 L17,16.3 L18,17.3 L18.9,18.4 L19.7,19.2 L20.4,20.1 L21,20.7 L20.9,18.9 L20.6,17.4 L20.3,16.1 L19.9,15 L19.4,14 L18.8,13.1 L18.2,12.3 L17.6,11.5 L17,10.8 L16.4,10 L15.8,9.2 L15.3,8.3 L14.9,7.2 L14.5,6.1 L14.2,4.7 L14.1,3.1 Z" fill="url(#linearGradient-74)"></path>
-                <path d="M21.6,21.7 L21.6,21.7 L21.6,20.5 L21.6,19.4 L21.7,18.2 L21.7,17 L21.8,15.9 L21.9,14.8 L22,13.7 L22.1,12.7 L22.3,11.6 L22.5,10.5 L22.8,9.4 L23,8.4 L23.3,7.4 L23.7,6.3 L24.1,5.3 L24.5,4.2 L22.8,5.8 L21.4,7.4 L20.5,8.9 L19.8,10.3 L19.3,11.6 L19.1,12.8 L19,14.1 L19.1,15.2 L19.4,16.2 L19.7,17.2 L20.1,18.1 L20.5,18.9 L20.9,19.8 L21.2,20.5 L21.5,21.2 L21.6,21.7 Z" fill="url(#linearGradient-75)"></path>
-                <path d="M4.5,25.8 L4.5,25.8 L5.4,25.9 L6.4,26.1 L7.3,26.2 L8.2,26.4 L9.2,26.4 L10.1,26.5 L11,26.5 L11.9,26.5 L12.8,26.4 L13.7,26.4 L14.6,26.3 L15.5,26.2 L16.5,26.2 L17.3,26.1 L18.3,25.9 L19.1,25.8 L18.4,26.2 L17.6,26.5 L16.8,26.8 L16,27.1 L15.1,27.4 L14.2,27.6 L13.3,27.9 L12.4,28 L11.4,28 L10.5,28 L9.5,28 L8.5,27.8 L7.5,27.5 L6.5,27.1 L5.5,26.5 L4.5,25.8 Z" fill="url(#linearGradient-76)"></path>
-                <path d="M9.9,30.5 L9.9,30.5 L9.2,30.6 L8.6,30.7 L7.9,30.9 L7.2,31.1 L6.5,31.4 L5.8,31.6 L5.2,31.9 L4.5,32.2 L3.8,32.6 L3.2,33 L2.6,33.4 L2,33.8 L1.5,34.3 L1,34.7 L0.6,35.2 L0.1,35.7 L0.6,34.3 L1.2,33.1 L1.9,32.1 L2.9,31.1 L3.9,30.3 L5.1,29.5 L6.4,28.9 L7.7,28.3 L9.1,27.9 L10.5,27.4 L12,27 L13.4,26.7 L14.9,26.4 L16.3,26.1 L17.6,25.9 L18.8,25.6 L18.2,25.8 L17.3,26.3 L16.3,27 L15,27.7 L13.7,28.6 L12.4,29.3 L11.1,30 L9.9,30.5 Z" fill="url(#linearGradient-77)"></path>
-                <path d="M7.3,40.9 L7.3,40.9 L6.7,39.6 L6.6,38.3 L6.7,37 L7.2,35.8 L7.9,34.7 L8.8,33.6 L9.9,32.6 L11.2,31.7 L12.4,30.7 L13.8,29.9 L15.2,29.1 L16.5,28.4 L17.7,27.7 L18.9,27.2 L19.9,26.6 L20.6,26.2 L19.8,27.9 L19,29.3 L18.1,30.4 L17.3,31.4 L16.5,32.1 L15.6,32.8 L14.7,33.3 L13.8,33.9 L13,34.4 L12.1,35 L11.2,35.6 L10.4,36.3 L9.6,37.1 L8.8,38.2 L8,39.4 L7.3,40.9 Z" fill="url(#linearGradient-78)"></path>
-                <path d="M21.9,26.6 L21.9,26.6 L21.3,27.6 L20.6,28.6 L20,29.5 L19.4,30.5 L18.9,31.4 L18.4,32.4 L17.9,33.3 L17.4,34.3 L16.9,35.3 L16.5,36.3 L16.1,37.2 L15.8,38.2 L15.5,39.2 L15.2,40.2 L14.9,41.3 L14.7,42.4 L14.1,40.2 L13.8,38.2 L13.8,36.5 L14,35 L14.3,33.7 L14.8,32.5 L15.5,31.5 L16.2,30.7 L17,30 L17.8,29.3 L18.7,28.8 L19.5,28.3 L20.2,27.9 L20.9,27.5 L21.5,27 L21.9,26.6 Z" fill="url(#linearGradient-79)"></path>
-            </g>
-        </g>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Feather" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 2392.5 4226.6" enable-background="new 0 0 2392.5 4226.6" xml:space="preserve">
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="-5167.0962" y1="697.5549" x2="-4570.1162" y2="1395.619" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0" style="stop-color:#F69923"/>
+	<stop  offset="0.3123" style="stop-color:#F79A23"/>
+	<stop  offset="0.8383" style="stop-color:#E97826"/>
+</linearGradient>
+<path fill="url(#SVGID_1_)" d="M1798.9,20.1C1732.6,59.2,1622.5,170,1491,330.5l120.8,228c84.8-121.3,170.9-230.4,257.8-323.6
+	c6.7-7.4,10.2-10.9,10.2-10.9c-3.4,3.6-6.8,7.3-10.2,10.9c-28.1,31-113.4,130.5-242.1,328.1c123.9-6.2,314.3-31.5,469.6-58.1
+	c46.2-258.8-45.3-377.3-45.3-377.3S1935.5-60.6,1798.9,20.1z"/>
+<path fill="none" d="M1594.4,1320.7c0.9-0.2,1.8-0.3,2.7-0.5l-17.4,1.9c-1.1,0.5-2,1-3.1,1.4
+	C1582.6,1322.6,1588.5,1321.6,1594.4,1320.7z"/>
+<path fill="none" d="M1471.1,1729.1c-9.9,2.2-20,3.9-30.2,5.4C1451.1,1733,1461.2,1731.2,1471.1,1729.1z"/>
+<path fill="none" d="M633.1,2645.2c1.3-3.4,2.6-6.8,3.8-10.2c26.6-70.2,52.9-138.4,79-204.9c29.3-74.6,58.2-146.8,86.8-216.8
+	c30.1-73.8,59.8-145.1,89.1-214c30.7-72.3,61-141.9,90.7-208.9c24.2-54.5,48-107.3,71.5-158.4c7.8-17,15.6-33.9,23.4-50.6
+	c15.4-33.1,30.7-65.6,45.7-97.3c13.9-29.3,27.7-57.9,41.4-86c4.5-9.4,9.1-18.6,13.6-27.9c0.7-1.5,1.5-3,2.2-4.5l-14.8,1.6
+	l-11.8-23.2c-1.1,2.3-2.3,4.5-3.5,6.8c-21.2,42.1-42.2,84.6-63,127.5c-12,24.8-24,49.7-35.9,74.7c-33,69.3-65.5,139.2-97.4,209.6
+	c-32.3,71.1-63.9,142.6-94.9,214.2c-30.5,70.3-60.3,140.7-89.6,210.9c-29.2,70.1-57.7,140-85.6,209.4
+	c-29.1,72.5-57.4,144.3-84.8,215.3c-6.2,16-12.4,32-18.5,48c-22,57.3-43.4,113.8-64.3,169.6l18.6,36.7l16.6-1.8
+	c0.6-1.7,1.2-3.4,1.8-5C580.1,2786.5,606.7,2714.9,633.1,2645.2z"/>
+<path fill="none" d="M1433.2,1735.7L1433.2,1735.7c0.1,0,0.1-0.1,0.2-0.1C1433.4,1735.6,1433.3,1735.6,1433.2,1735.7z"/>
+<path fill="#BE202E" d="M1393.2,1934.8c-15.4,2.8-31.3,5.5-47.6,8.3c-0.1,0-0.2,0.1-0.3,0.1c8.2-1.2,16.3-2.4,24.3-3.8
+	C1377.6,1938,1385.4,1936.5,1393.2,1934.8z"/>
+<path opacity="0.35" fill="#BE202E" d="M1393.2,1934.8c-15.4,2.8-31.3,5.5-47.6,8.3c-0.1,0-0.2,0.1-0.3,0.1
+	c8.2-1.2,16.3-2.4,24.3-3.8C1377.6,1938,1385.4,1936.5,1393.2,1934.8z"/>
+<path fill="#BE202E" d="M1433.6,1735.5c0,0-0.1,0-0.1,0.1c-0.1,0-0.1,0.1-0.2,0.1c2.6-0.3,5.1-0.8,7.6-1.1
+	c10.3-1.5,20.4-3.3,30.2-5.4C1458.8,1731.2,1446.3,1733.4,1433.6,1735.5L1433.6,1735.5L1433.6,1735.5z"/>
+<path opacity="0.35" fill="#BE202E" d="M1433.6,1735.5c0,0-0.1,0-0.1,0.1c-0.1,0-0.1,0.1-0.2,0.1c2.6-0.3,5.1-0.8,7.6-1.1
+	c10.3-1.5,20.4-3.3,30.2-5.4C1458.8,1731.2,1446.3,1733.4,1433.6,1735.5L1433.6,1735.5L1433.6,1735.5z"/>
+<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="-9585.3418" y1="620.5048" x2="-5326.209" y2="620.5048" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0.3233" style="stop-color:#9E2064"/>
+	<stop  offset="0.6302" style="stop-color:#C92037"/>
+	<stop  offset="0.7514" style="stop-color:#CD2335"/>
+	<stop  offset="1" style="stop-color:#E97826"/>
+</linearGradient>
+<path fill="url(#SVGID_2_)" d="M1255.7,1147.6c36.7-68.6,73.9-135.7,111.5-201c39-67.8,78.5-133.6,118.4-197c2.3-3.7,4.7-7.5,7-11.3
+	c39.4-62.4,79.2-122.4,119.3-179.8l-120.8-228c-9.1,11.1-18.2,22.4-27.5,33.9c-34.8,43.4-71,90.1-108.1,139.6
+	c-41.8,55.8-84.8,115.4-128.5,177.9c-40.3,57.8-81.2,118.3-122.1,180.9c-34.8,53.3-69.8,108.2-104.5,164.5c-1.3,2.1-2.6,4.2-3.9,6.3
+	l157.2,310.5C1187.3,1277.6,1221.3,1212,1255.7,1147.6z"/>
+<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="-9071.207" y1="1047.6898" x2="-6533.1782" y2="1047.6898" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0" style="stop-color:#282662"/>
+	<stop  offset="9.548390e-02" style="stop-color:#662E8D"/>
+	<stop  offset="0.7882" style="stop-color:#9F2064"/>
+	<stop  offset="0.9487" style="stop-color:#CD2032"/>
+</linearGradient>
+<path fill="url(#SVGID_3_)" d="M539.7,2897.1c-20.8,57.2-41.7,115.4-62.7,174.9c-0.3,0.9-0.6,1.7-0.9,2.6c-3,8.4-5.9,16.8-8.9,25.2
+	c-14.1,40.1-26.4,76.2-54.5,158.3c46.3,21.1,83.5,76.7,118.7,139.8c-3.7-65.3-30.8-126.7-82.1-174.2
+	c228.3,10.3,425-47.4,526.7-214.3c9.1-14.9,17.4-30.5,24.9-47.2c-46.2,58.6-103.5,83.5-211.4,77.4c-0.2,0.1-0.5,0.2-0.7,0.3
+	c0.2-0.1,0.5-0.2,0.7-0.3c158.8-71.1,238.5-139.3,308.9-252.4c16.7-26.8,32.9-56.1,49.5-88.6C1009,2841.2,848.1,2881.8,678.6,2851
+	l-127.1,13.9C547.5,2875.6,543.6,2886.3,539.7,2897.1z"/>
+<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="-9346.126" y1="580.817" x2="-5086.9941" y2="580.817" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0.3233" style="stop-color:#9E2064"/>
+	<stop  offset="0.6302" style="stop-color:#C92037"/>
+	<stop  offset="0.7514" style="stop-color:#CD2335"/>
+	<stop  offset="1" style="stop-color:#E97826"/>
+</linearGradient>
+<path fill="url(#SVGID_4_)" d="M599,2612.4c27.5-71,55.8-142.8,84.8-215.3c27.8-69.4,56.4-139.2,85.6-209.4
+	c29.2-70.2,59.1-140.5,89.6-210.9c31-71.6,62.7-143.1,94.9-214.2c31.9-70.3,64.4-140.3,97.4-209.6c11.9-25,23.9-49.9,35.9-74.7
+	c20.8-42.9,41.8-85.4,63-127.5c1.1-2.3,2.3-4.5,3.5-6.8l-157.2-310.5c-2.6,4.2-5.1,8.4-7.7,12.6c-36.6,59.8-73.1,121-108.9,183.5
+	c-36.2,63.1-71.7,127.4-106.4,192.6c-29.3,55-57.9,110.5-85.7,166.5c-5.6,11.4-11.1,22.6-16.6,33.9
+	c-34.3,70.5-65.2,138.6-93.2,204.1c-31.7,74.2-59.6,145.1-84,212.3c-16.1,44.2-30.7,86.9-44.1,127.9c-11,35-21.5,70.1-31.4,105
+	c-23.5,82.3-43.7,164.4-60.3,246.2L516.2,2830c20.9-55.8,42.3-112.3,64.3-169.6C586.6,2644.5,592.8,2628.4,599,2612.4z"/>
+<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="-9035.5029" y1="638.4408" x2="-6797.2012" y2="638.4408" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0" style="stop-color:#282662"/>
+	<stop  offset="9.548390e-02" style="stop-color:#662E8D"/>
+	<stop  offset="0.7882" style="stop-color:#9F2064"/>
+	<stop  offset="0.9487" style="stop-color:#CD2032"/>
+</linearGradient>
+<path fill="url(#SVGID_5_)" d="M356.1,2529.2c-19.8,99.8-33.9,199.2-41,298c-0.2,3.5-0.6,6.9-0.8,10.4
+	c-49.3-79-181.3-156.1-181-155.4c94.5,137,166.2,273,176.9,406.5c-50.6,10.4-119.9-4.6-200-34.1c83.5,76.7,146.2,97.9,170.6,103.6
+	c-76.7,4.8-156.6,57.5-237.1,118.2c117.7-48,212.8-67,280.9-51.6C216.6,3530.6,108.3,3868.2,0,4226.6c33.2-9.8,53-32.1,64.1-62.3
+	c19.3-64.9,147.4-490.7,348.1-1050.4c5.7-15.9,11.5-31.9,17.3-48c1.6-4.5,3.3-9,4.9-13.4c21.2-58.7,43.2-118.6,65.9-179.7
+	c5.2-13.9,10.4-27.8,15.6-41.8c0.1-0.3,0.2-0.6,0.3-0.8l-157.8-311.8C357.7,2521.9,356.8,2525.5,356.1,2529.2z"/>
+<linearGradient id="SVGID_6_" gradientUnits="userSpaceOnUse" x1="-9346.126" y1="1021.6218" x2="-5086.9941" y2="1021.6218" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0.3233" style="stop-color:#9E2064"/>
+	<stop  offset="0.6302" style="stop-color:#C92037"/>
+	<stop  offset="0.7514" style="stop-color:#CD2335"/>
+	<stop  offset="1" style="stop-color:#E97826"/>
+</linearGradient>
+<path fill="url(#SVGID_6_)" d="M1178.1,1370.3c-4.5,9.2-9,18.5-13.6,27.9c-13.6,28.1-27.4,56.7-41.4,86
+	c-15.1,31.7-30.3,64.1-45.7,97.3c-7.8,16.7-15.5,33.5-23.4,50.6c-23.5,51.1-47.3,103.9-71.5,158.4c-29.7,67-60,136.6-90.7,208.9
+	c-29.3,68.9-59,140.2-89.1,214c-28.6,70-57.5,142.3-86.8,216.8c-26.1,66.5-52.4,134.7-79,204.9c-1.3,3.4-2.6,6.8-3.8,10.2
+	c-26.4,69.7-53,141.3-79.8,214.7c-0.6,1.7-1.2,3.4-1.8,5l127.1-13.9c-2.5-0.5-5.1-0.8-7.6-1.3c152-18.9,354-132.5,484.6-272.7
+	c60.2-64.6,114.8-140.8,165.3-230c37.6-66.4,72.9-140,106.5-221.5c29.4-71.2,57.6-148.3,84.8-231.9c-34.9,18.4-74.9,31.9-119,41.3
+	c-7.7,1.6-15.6,3.2-23.6,4.6c-8,1.4-16.1,2.7-24.3,3.8l0,0l0,0c0.1,0,0.2-0.1,0.3-0.1c141.7-54.5,231.1-159.8,296.1-288.7
+	c-37.3,25.4-97.9,58.7-170.5,74.7c-9.9,2.2-20,3.9-30.2,5.4c-2.6,0.4-5.1,0.8-7.6,1.1l0,0l0,0c0.1,0,0.1-0.1,0.2-0.1
+	c0,0,0.1,0,0.1-0.1l0,0c49.2-20.6,90.7-43.6,126.7-70.8c7.7-5.8,15.2-11.8,22.4-18.1c11-9.5,21.4-19.5,31.4-30
+	c6.4-6.7,12.6-13.6,18.6-20.8c14.1-16.8,27.3-34.9,39.7-54.6c3.8-6,7.5-12.1,11.2-18.4c4.7-9.1,9.2-18,13.6-26.8
+	c19.8-39.8,35.6-75.3,48.2-106.5c6.3-15.6,11.8-30,16.5-43.4c1.9-5.3,3.7-10.5,5.4-15.5c5-15,9.1-28.3,12.3-40
+	c4.8-17.5,7.7-31.4,9.3-41.5l0,0l0,0c-4.8,3.8-10.3,7.6-16.5,11.3c-42.8,25.6-116.2,48.8-175.4,59.7l116.7-12.8l-116.7,12.8
+	c-0.9,0.2-1.8,0.3-2.7,0.5c-5.9,1-11.9,1.9-17.9,2.9c1.1-0.5,2-1,3.1-1.4l-399.3,43.8C1179.6,1367.4,1178.9,1368.8,1178.1,1370.3z"
+	/>
+<linearGradient id="SVGID_7_" gradientUnits="userSpaceOnUse" x1="-9610.334" y1="999.733" x2="-5351.2017" y2="999.733" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0.3233" style="stop-color:#9E2064"/>
+	<stop  offset="0.6302" style="stop-color:#C92037"/>
+	<stop  offset="0.7514" style="stop-color:#CD2335"/>
+	<stop  offset="1" style="stop-color:#E97826"/>
+</linearGradient>
+<path fill="url(#SVGID_7_)" d="M1627.6,563.1c-35.5,54.5-74.3,116.4-116,186.5c-2.2,3.6-4.4,7.4-6.6,11.1
+	c-36,60.7-74.3,127.3-114.5,200.3c-34.8,63-71,130.6-108.6,203.3c-32.8,63.3-66.7,130.5-101.5,201.6l399.3-43.8
+	c116.3-53.5,168.3-101.9,218.8-171.9c13.4-19.3,26.9-39.5,40.3-60.4c41-64,81.2-134.5,117.2-204.6c34.7-67.7,65.3-134.8,88.8-195.3
+	c14.9-38.5,26.9-74.3,35.2-105.7c7.3-27.7,13-54,17.4-79.1C1941.9,531.6,1751.5,557,1627.6,563.1z"/>
+<path fill="#BE202E" d="M1369.6,1939.4c-8,1.4-16.1,2.7-24.3,3.8l0,0C1353.5,1942.1,1361.6,1940.8,1369.6,1939.4z"/>
+<path opacity="0.35" fill="#BE202E" d="M1369.6,1939.4c-8,1.4-16.1,2.7-24.3,3.8l0,0C1353.5,1942.1,1361.6,1940.8,1369.6,1939.4z"/>
+<linearGradient id="SVGID_8_" gradientUnits="userSpaceOnUse" x1="-9346.126" y1="1152.7261" x2="-5086.9941" y2="1152.7261" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0.3233" style="stop-color:#9E2064"/>
+	<stop  offset="0.6302" style="stop-color:#C92037"/>
+	<stop  offset="0.7514" style="stop-color:#CD2335"/>
+	<stop  offset="1" style="stop-color:#E97826"/>
+</linearGradient>
+<path fill="url(#SVGID_8_)" d="M1369.6,1939.4c-8,1.4-16.1,2.7-24.3,3.8l0,0C1353.5,1942.1,1361.6,1940.8,1369.6,1939.4z"/>
+<path fill="#BE202E" d="M1433.2,1735.7c2.6-0.3,5.1-0.8,7.6-1.1C1438.3,1734.9,1435.8,1735.3,1433.2,1735.7L1433.2,1735.7z"/>
+<path opacity="0.35" fill="#BE202E" d="M1433.2,1735.7c2.6-0.3,5.1-0.8,7.6-1.1C1438.3,1734.9,1435.8,1735.3,1433.2,1735.7
+	L1433.2,1735.7z"/>
+<linearGradient id="SVGID_9_" gradientUnits="userSpaceOnUse" x1="-9346.126" y1="1137.7247" x2="-5086.9941" y2="1137.7247" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0.3233" style="stop-color:#9E2064"/>
+	<stop  offset="0.6302" style="stop-color:#C92037"/>
+	<stop  offset="0.7514" style="stop-color:#CD2335"/>
+	<stop  offset="1" style="stop-color:#E97826"/>
+</linearGradient>
+<path fill="url(#SVGID_9_)" d="M1433.2,1735.7c2.6-0.3,5.1-0.8,7.6-1.1C1438.3,1734.9,1435.8,1735.3,1433.2,1735.7L1433.2,1735.7z"
+	/>
+<path fill="#BE202E" d="M1433.5,1735.6c0,0,0.1,0,0.1-0.1l0,0l0,0l0,0C1433.6,1735.5,1433.5,1735.5,1433.5,1735.6z"/>
+<path opacity="0.35" fill="#BE202E" d="M1433.5,1735.6c0,0,0.1,0,0.1-0.1l0,0l0,0l0,0C1433.6,1735.5,1433.5,1735.5,1433.5,1735.6z"
+	/>
+<linearGradient id="SVGID_10_" gradientUnits="userSpaceOnUse" x1="-6953.4072" y1="1134.7161" x2="-6011.9995" y2="1134.7161" gradientTransform="matrix(0.4226 -0.9063 0.9063 0.4226 3144.8108 -4619.2983)">
+	<stop  offset="0.3233" style="stop-color:#9E2064"/>
+	<stop  offset="0.6302" style="stop-color:#C92037"/>
+	<stop  offset="0.7514" style="stop-color:#CD2335"/>
+	<stop  offset="1" style="stop-color:#E97826"/>
+</linearGradient>
+<path fill="url(#SVGID_10_)" d="M1433.5,1735.6c0,0,0.1,0,0.1-0.1l0,0l0,0l0,0C1433.6,1735.5,1433.5,1735.5,1433.5,1735.6z"/>
+<path fill="#6D6E71" d="M2218.7,387v11.7h27.4v77.4h12.7v-77.4h27.6V387H2218.7z M2377,387l-30.6,62.2l-30.8-62.2h-15.3v89.1h11.7
+	v-70.7l30.3,61.3h8.1l30.3-61.3v70.7h11.7V387H2377z"/>
 </svg>


### PR DESCRIPTION
The logo has been updated in 2016. Here's the official logos : https://www.apache.org/foundation/press/kit/#links