### PR TITLE
Include SVGs when calculating project's language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Include SVGs when calculating project's language stats
+*.svg linguist-detectable


### PR DESCRIPTION
Since this repository's almost entirely composed of SVG files, it makes sense to classify it a an SVG project. By default, GitHub doesn't include SVGs when computing language statistics, but this can be changed [using an override](https://github.com/github/linguist/blob/master/docs/overrides.md#detectable).