### PR TITLE
FIX RxDB url

### DIFF
--- a/logos.json
+++ b/logos.json
@@ -8812,7 +8812,7 @@
   {
     "name": "RxDB",
     "shortname": "rxdb",
-    "url": "https://pubkey.github.io/rxdb/",
+    "url": "https://rxdb.info/",
     "files": [
       "rxdb.svg"
     ]

--- a/logos.json
+++ b/logos.json
@@ -4142,7 +4142,7 @@
     "url": "https://www.gnunet.org/en/index.html",
     "files": [
       "gnu-net.svg"
-    ]
+    ]Update logos.json
   },
   {
     "name": "GnuPG",
@@ -11535,3 +11535,4 @@
     ]
   }
 ]
+

--- a/logos.json
+++ b/logos.json
@@ -4142,7 +4142,7 @@
     "url": "https://www.gnunet.org/en/index.html",
     "files": [
       "gnu-net.svg"
-    ]Update logos.json
+    ]
   },
   {
     "name": "GnuPG",
@@ -11535,4 +11535,3 @@
     ]
   }
 ]
-


### PR DESCRIPTION
The url was wrong so I changed it to the [correct one](https://rxdb.info/).